### PR TITLE
Remove geolocation iso2 validation if missing

### DIFF
--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -131,9 +131,7 @@ class CommonFigureValidationMixin:
             return errors
         location_code = country.iso2
         if not location_code:
-            errors.update({
-                'geo_locations': 'Invalid country for figure: Please contact administrator'
-            })
+            # ignore iso2 validation if missing
             return errors
         geo_locations_code = set([
             location['country_code'] for location in attrs['geo_locations']

--- a/apps/entry/tests/test_serializers.py
+++ b/apps/entry/tests/test_serializers.py
@@ -368,6 +368,7 @@ class TestFigureSerializer(HelixTestCase):
             event=self.event
         )
         self.fig_cat = FigureCategoryFactory.create()
+        self.country = country1
         self.data = {
             "uuid": str(uuid4()),
             "entry": self.entry.id,
@@ -409,7 +410,7 @@ class TestFigureSerializer(HelixTestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertIsNone(serializer.data['displacement_occurred'])
 
-    def test_invalid_geo_locations(self):
+    def test_invalid_geo_locations_country_codes(self):
         self.data['geo_locations'] = [
             {
                 "country": "Nepal",
@@ -444,6 +445,14 @@ class TestFigureSerializer(HelixTestCase):
                                       context={'request': self.request})
         self.assertFalse(serializer.is_valid())
         self.assertIn('geo_locations', serializer.errors)
+
+        # if the figure country iso2 is missing, ignore the validation
+        self.country.iso2 = None
+        self.country.save()
+
+        serializer = FigureSerializer(data=self.data,
+                                      context={'request': self.request})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
     def test_invalid_displacement(self):
         self.data['disaggregation_displacement_urban'] = 10


### PR DESCRIPTION
Addresses [Disable validation for country if there is no iso2](https://freedcamp.com/view/2779007/tasks/panel/task/40119955)

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
