### PR TITLE
Make user .is_active char rather than bool

### DIFF
--- a/apps/users/filters.py
+++ b/apps/users/filters.py
@@ -13,13 +13,18 @@ class UserFilter(AllowInitialFilterSetMixin, django_filters.FilterSet):
                                      distinct=True)
     roleIn = StringListFilter(method='filter_role_in')
     full_name = django_filters.CharFilter(method='filter_full_name')
-    include_inactive = django_filters.BooleanFilter(method='filter_include_inactive',
-                                                    initial=False)
     id = django_filters.CharFilter(field_name='id', lookup_expr='iexact')
+    is_active = django_filters.CharFilter(method='filter_is_active')
 
     class Meta:
         model = User
-        fields = ['email', 'is_active']
+        fields = ['email']
+
+    def filter_is_active(self, queryset, name, value):
+        value = value.lower()
+        if value in ['true', 'false']:
+            return queryset.filter(is_active=value == 'true')
+        return queryset
 
     def filter_role_in(self, queryset, name, value):
         if not value:
@@ -42,11 +47,6 @@ class UserFilter(AllowInitialFilterSetMixin, django_filters.FilterSet):
         ).annotate(
             idx=StrIndex('full', Value(value.lower()))
         ).filter(idx__gt=0).order_by('idx')
-
-    def filter_include_inactive(self, queryset, name, value):
-        if value is False:
-            return queryset.filter(is_active=True)
-        return queryset
 
 
 class ReviewerUserFilter(UserFilter):

--- a/apps/users/tests/test_filters.py
+++ b/apps/users/tests/test_filters.py
@@ -24,14 +24,14 @@ class TestUserFilter(HelixTestCase):
         filtered = UserFilter(data).qs
         self.assertEqual([each for each in filtered], [u3])
 
-    def test_filter_users_defaults_to_active_only(self):
+    def test_filter_users_is_active(self):
         u1 = UserFactory.create(first_name='abc', last_name='def', is_active=False)
         u2 = UserFactory.create(first_name='bcd', last_name='efa', is_active=True)
 
         data = dict()
+        data['is_active'] = 'true'
         filtered = UserFilter(data).qs
         self.assertEqual([each for each in filtered], [u2])
-
-        data['include_inactive'] = True
+        data['is_active'] = 'false'
         filtered = UserFilter(data).qs
-        self.assertEqual([each for each in filtered], [u1, u2])
+        self.assertEqual([each for each in filtered], [u1])

--- a/utils/graphene/fields.py
+++ b/utils/graphene/fields.py
@@ -229,6 +229,7 @@ class DjangoPaginatedListObjectField(DjangoFilterPaginateListField):
             # TODO: qs should be executed only when we access the results node in the future
             qs = info.context.get_dataloader(
                 parent_class.__name__,
+                # NOTE: this is inadequate if we use ALIASING
                 self.related_name,
             ).load(
                 root.id,


### PR DESCRIPTION
Addresses
- [x] [Bug: "isActive" filter doesn't work](https://freedcamp.com/view/2779007/tasks/panel/task/39728091)

## Breaking

- Removes `includeInactive` filter
  - To have this behavior, add `isActive=true` flag where necessary.

## Changes

- Add `isActive` filter in user list which takes `char/string` true/false over bool.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
