### PR TITLE
Fix user list filter by user role

### DIFF
--- a/apps/users/filters.py
+++ b/apps/users/filters.py
@@ -64,7 +64,7 @@ class UserFilter(AllowInitialFilterSetMixin, django_filters.FilterSet):
     @property
     def qs(self):
         # to get the highest role
-        return super().qs.prefetch_related('portfolios')
+        return super().qs.prefetch_related('portfolios').distinct()
 
 
 class PortfolioFilter(django_filters.FilterSet):

--- a/apps/users/tests/test_filters.py
+++ b/apps/users/tests/test_filters.py
@@ -39,7 +39,7 @@ class TestUserFilter(HelixTestCase):
         self.assertEqual([each for each in filtered], [u2])
 
         data['include_inactive'] = True
-        filtered = UserFilter(data).qs
+        filtered = UserFilter(data).qs.order_by('pk')
         self.assertEqual([each for each in filtered], [u1, u2])
 
     def test_filter_user_by_role(self):


### PR DESCRIPTION
## Changes
Fixes duplicated users in users list when applying filter by user role (`MONITORING_EXPERT`)

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
