### PR TITLE
Add name filter in figure term list query

### DIFF
--- a/apps/entry/filters.py
+++ b/apps/entry/filters.py
@@ -5,8 +5,13 @@ from apps.entry.models import (
     EntryReviewer,
     OSMName,
     Figure,
+    FigureTerm,
 )
-from utils.filters import StringListFilter, IDListFilter
+from utils.filters import (
+    StringListFilter,
+    IDListFilter,
+    NameFilterMixin,
+)
 
 
 class OSMNameFilter(df.FilterSet):
@@ -114,3 +119,13 @@ class EntryReviewerFilter(df.FilterSet):
             # map enum names to values
             return queryset.filter(status__in=[EntryReviewer.REVIEW_STATUS.get(each) for each in value])
         return queryset
+
+
+class FigureTermFilter(NameFilterMixin, df.FilterSet):
+    name = df.CharFilter(method='_filter_name')
+
+    class Meta:
+        model = FigureTerm
+        fields = {
+            'is_housing_related': ('exact',),
+        }

--- a/apps/entry/schema.py
+++ b/apps/entry/schema.py
@@ -18,7 +18,12 @@ from apps.entry.enums import (
     IdentifierGrapheneEnum,
     DisaggregatedAgeSexGrapheneEnum,
 )
-from apps.entry.filters import EntryFilter, EntryReviewerFilter, OSMNameFilter
+from apps.entry.filters import (
+    EntryFilter,
+    EntryReviewerFilter,
+    OSMNameFilter,
+    FigureTermFilter,
+)
 from apps.entry.models import (
     Figure,
     FigureTag,
@@ -110,10 +115,7 @@ class FigureTermType(DjangoObjectType):
 class FigureTermListType(CustomDjangoListObjectType):
     class Meta:
         model = FigureTerm
-        filter_fields = {
-            'is_housing_related': ('exact',),
-            'name': ('icontains',),
-        }
+        filterset_class = FigureTermFilter
 
 
 class FigureType(DjangoObjectType):

--- a/apps/entry/schema.py
+++ b/apps/entry/schema.py
@@ -110,9 +110,10 @@ class FigureTermType(DjangoObjectType):
 class FigureTermListType(CustomDjangoListObjectType):
     class Meta:
         model = FigureTerm
-        filter_fields = (
-            'is_housing_related',
-        )
+        filter_fields = {
+            'is_housing_related': ('exact',),
+            'name': ('icontains',),
+        }
 
 
 class FigureType(DjangoObjectType):

--- a/apps/entry/tests/test_filters.py
+++ b/apps/entry/tests/test_filters.py
@@ -1,7 +1,7 @@
 from apps.users.enums import USER_ROLE
 from apps.review.models import Review
-from apps.entry.models import EntryReviewer
-from apps.entry.filters import EntryFilter
+from apps.entry.models import EntryReviewer, FigureTerm
+from apps.entry.filters import EntryFilter, FigureTermFilter
 from utils.tests import HelixTestCase, create_user_with_role
 from utils.factories import (
     EntryFactory,
@@ -68,3 +68,66 @@ class TestEntryFilter(HelixTestCase):
 
         fqs = EntryFilter().qs
         self.assertEqual(fqs.count(), 2)
+
+
+class TestFigureTermFilter(HelixTestCase):
+    def setUp(self):
+        FigureTerm.objects.all().delete()
+        self.ft1 = FigureTerm.objects.create(
+            is_housing_related=True,
+            name='one'
+        )
+        self.ft2 = FigureTerm.objects.create(
+            is_housing_related=False,
+            name='two'
+        )
+        self.ft3 = FigureTerm.objects.create(
+            is_housing_related=True,
+            name='three'
+        )
+        self.ft3 = FigureTerm.objects.create(
+            is_housing_related=False,
+            name='one two'
+        )
+
+    def test_filter_is_housing_related(self):
+        qs = FigureTermFilter(
+            data=dict(is_housing_related=True)
+        ).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertListEqual(
+            list(qs),
+            list(FigureTerm.objects.filter(is_housing_related=True))
+        )
+
+        qs = FigureTermFilter(
+            data=dict(is_housing_related=False)
+        ).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertListEqual(
+            list(qs),
+            list(FigureTerm.objects.filter(is_housing_related=False))
+        )
+
+    def test_filter_name(self):
+        text = 'one'
+        qs = FigureTermFilter(
+            data=dict(name=text)
+        ).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertListEqual(
+            list(qs),
+            list(FigureTerm.objects.filter(name__icontains=text))
+        )
+        self.assertIn(self.ft3, qs)
+
+        text = 'two'
+        qs = FigureTermFilter(
+            data=dict(name=text)
+        ).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertListEqual(
+            list(qs),
+            list(FigureTerm.objects.filter(name__icontains=text))
+        )
+        self.assertIn(self.ft3, qs)


### PR DESCRIPTION
## Changes

* Added a name filter in figure terms list query

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
