### PR TITLE
Add unescape to clean text

### DIFF
--- a/apps/entry/tests/test_models.py
+++ b/apps/entry/tests/test_models.py
@@ -277,6 +277,23 @@ class TestEntryModel(HelixTestCase):
         e.refresh_from_db()
         assert e.review_status == EntryReviewer.REVIEW_STATUS.REVIEW_COMPLETED
 
+    def test_should_remove_html_and_script_tags_from_text_field(self):
+        e = EntryFactory.create(created_by=self.editor)
+        html_data = '<html><body><h2>test</h2><p> test</p><p id="demo"> test</p><script></script></body></html>'
+        e.source_excerpt = html_data
+        e.save()
+        e.refresh_from_db()
+        print(e.source_excerpt)
+        self.assertEqual(e.source_excerpt, 'test test test')
+
+    def test_should_allow_special_chars_in_text_field(self):
+        e = EntryFactory.create(created_by=self.editor)
+        e.calculation_logic = '~!@#$%^&*<>?/'
+        e.save()
+        e.refresh_from_db()
+        print(e.source_excerpt)
+        self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
+
 
 class TestCloneEntry(HelixTestCase):
     def test_clone_relevant_fields_only(self):

--- a/apps/entry/tests/test_models.py
+++ b/apps/entry/tests/test_models.py
@@ -297,6 +297,17 @@ class TestEntryModel(HelixTestCase):
         [title](https://www.example.com)
         ![alt text](image.jpg)
         """
+        e = EntryFactory.create(created_by=self.editor)
+        e.source_excerpt = html_data
+        e.calculation_logic = '~!@#$%^&*<>?/'
+        e.article_title = markup_text
+        e.save()
+        e.refresh_from_db()
+
+        self.assertEqual(e.source_excerpt, 'test test test')
+        self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
+        self.assertEqual(e.article_title, markup_text)
+
         markup_and_html_mixed_data = """
         # H1 heading 1
         ## H2 heading 2
@@ -304,7 +315,7 @@ class TestEntryModel(HelixTestCase):
         **bold text**
         *italicized text*
         > blockquote
-        1. <html><head>test</head><body><p>First item</p><script></script></body></html>
+        1. <html><body><p>First item</p><script></script></body></html>
         2. <h1>Second item</h1>
         3. <div><p>Third item</p></div>
         - <li>First item</li>
@@ -316,23 +327,30 @@ class TestEntryModel(HelixTestCase):
         ![alt text](image.jpg)
         <script>console.log("test")</script>
         """
-
-        e = EntryFactory.create(created_by=self.editor)
-        e.source_excerpt = html_data
-        e.calculation_logic = '~!@#$%^&*<>?/'
-        e.article_title = markup_text
-        e.save()
-        e.refresh_from_db()
-
-        self.assertEqual(e.source_excerpt, 'test test test')
-        self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
-        self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
-        self.assertEqual(e.article_title, markup_text)
+        markup_and_html_mixed_data_cleaned = """
+        # H1 heading 1
+        ## H2 heading 2
+        ### H3 heading 3
+        **bold text**
+        *italicized text*
+        > blockquote
+        1. First item
+        2. Second item
+        3. Third item
+        - <li>First item</li>
+        - <li>Second item</li>
+        - <li>Third item</li>
+        `code`
+        ---
+        [title](https://www.example.com)
+        ![alt text](image.jpg)
+        console.log("test")
+        """
 
         e.calculation_logic = markup_and_html_mixed_data
         e.save()
         e.refresh_from_db()
-        self.assertEqual(e.article_title, markup_text)
+        self.assertEqual(e.calculation_logic, markup_and_html_mixed_data_cleaned)
 
 
 class TestCloneEntry(HelixTestCase):

--- a/apps/entry/tests/test_models.py
+++ b/apps/entry/tests/test_models.py
@@ -278,10 +278,7 @@ class TestEntryModel(HelixTestCase):
         assert e.review_status == EntryReviewer.REVIEW_STATUS.REVIEW_COMPLETED
 
     def test_text_field_should_accept_markup_and_speicial_should_remove_html_tags(self):
-        e = EntryFactory.create(created_by=self.editor)
         html_data = '<html><body><h2>test</h2><p> test</p><p id="demo"> test</p><script></script></body></html>'
-        e.source_excerpt = html_data
-        e.calculation_logic = '~!@#$%^&*<>?/'
         markup_text = """
         # H1 heading 1
         ## H2 heading 2
@@ -300,12 +297,41 @@ class TestEntryModel(HelixTestCase):
         [title](https://www.example.com)
         ![alt text](image.jpg)
         """
+        markup_and_html_mixed_data = """
+        # H1 heading 1
+        ## H2 heading 2
+        ### H3 heading 3
+        **bold text**
+        *italicized text*
+        > blockquote
+        1. <html><head>test</head><body><p>First item</p><script></script></body></html>
+        2. <h1>Second item</h1>
+        3. <div><p>Third item</p></div>
+        - <li>First item</li>
+        - <li>Second item</li>
+        - <li>Third item</li>
+        `code`
+        ---
+        [title](https://www.example.com)
+        ![alt text](image.jpg)
+        <script>console.log("test")</script>
+        """
+
+        e = EntryFactory.create(created_by=self.editor)
+        e.source_excerpt = html_data
+        e.calculation_logic = '~!@#$%^&*<>?/'
         e.article_title = markup_text
         e.save()
         e.refresh_from_db()
+
         self.assertEqual(e.source_excerpt, 'test test test')
         self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
         self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
+        self.assertEqual(e.article_title, markup_text)
+
+        e.calculation_logic = markup_and_html_mixed_data
+        e.save()
+        e.refresh_from_db()
         self.assertEqual(e.article_title, markup_text)
 
 

--- a/apps/entry/tests/test_models.py
+++ b/apps/entry/tests/test_models.py
@@ -277,22 +277,36 @@ class TestEntryModel(HelixTestCase):
         e.refresh_from_db()
         assert e.review_status == EntryReviewer.REVIEW_STATUS.REVIEW_COMPLETED
 
-    def test_should_remove_html_and_script_tags_from_text_field(self):
+    def test_text_field_should_accept_markup_and_speicial_should_remove_html_tags(self):
         e = EntryFactory.create(created_by=self.editor)
         html_data = '<html><body><h2>test</h2><p> test</p><p id="demo"> test</p><script></script></body></html>'
         e.source_excerpt = html_data
-        e.save()
-        e.refresh_from_db()
-        print(e.source_excerpt)
-        self.assertEqual(e.source_excerpt, 'test test test')
-
-    def test_should_allow_special_chars_in_text_field(self):
-        e = EntryFactory.create(created_by=self.editor)
         e.calculation_logic = '~!@#$%^&*<>?/'
+        markup_text = """
+        # H1 heading 1
+        ## H2 heading 2
+        ### H3 heading 3
+        **bold text**
+        *italicized text*
+        > blockquote
+        1. First item
+        2. Second item
+        3. Third item
+        - First item
+        - Second item
+        - Third item
+        `code`
+        ---
+        [title](https://www.example.com)
+        ![alt text](image.jpg)
+        """
+        e.article_title = markup_text
         e.save()
         e.refresh_from_db()
-        print(e.source_excerpt)
+        self.assertEqual(e.source_excerpt, 'test test test')
         self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
+        self.assertEqual(e.calculation_logic, '~!@#$%^&*<>?/')
+        self.assertEqual(e.article_title, markup_text)
 
 
 class TestCloneEntry(HelixTestCase):

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db.models import FileField, TextField
 from django.db.models.fields.files import FieldFile
 from html import unescape
+from django.utils.html import strip_tags
 
 
 class CachedFieldFile(FieldFile):
@@ -34,7 +35,7 @@ class BleachedTextField(TextField):
     def get_db_prep_value(self, *args, **kwargs):
         value = super().get_db_prep_value(*args, **kwargs)
         if isinstance(value, str):
-            return unescape(bleach.clean(value))
+            return unescape(bleach.clean(strip_tags(value)))
         return value
 
 

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -5,7 +5,6 @@ from django.core.cache import cache
 from django.db.models import FileField, TextField
 from django.db.models.fields.files import FieldFile
 from html import unescape
-from django.utils.html import strip_tags
 
 
 class CachedFieldFile(FieldFile):
@@ -35,7 +34,7 @@ class BleachedTextField(TextField):
     def get_db_prep_value(self, *args, **kwargs):
         value = super().get_db_prep_value(*args, **kwargs)
         if isinstance(value, str):
-            return unescape(bleach.clean(strip_tags(value)))
+            return unescape(bleach.clean(value, strip=True))
         return value
 
 

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import FileField, TextField
 from django.db.models.fields.files import FieldFile
+from html import unescape
 
 
 class CachedFieldFile(FieldFile):
@@ -33,7 +34,7 @@ class BleachedTextField(TextField):
     def get_db_prep_value(self, *args, **kwargs):
         value = super().get_db_prep_value(*args, **kwargs)
         if isinstance(value, str):
-            return bleach.clean(value)
+            return unescape(bleach.clean(value))
         return value
 
 


### PR DESCRIPTION
Related to https://github.com/idmc-labs/Helix2.0/issues/176

## Changes

* Add unescape to clean text

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
