### PR TITLE
Remove unnecessary prefetch from extraction

### DIFF
--- a/apps/extraction/filters.py
+++ b/apps/extraction/filters.py
@@ -308,11 +308,9 @@ class EntryExtractionFilterSet(df.FilterSet):
 
     @property
     def qs(self):
-        figure_ids = super().qs.values_list('figures', flat=True)
-        figures = Figure.objects.filter(id__in=figure_ids)
         return super().qs.annotate(
-            **Entry._total_figure_disaggregation_subquery(figures=figures),
-        ).prefetch_related('review_comments', 'figures', 'figures__context_of_violence').distinct()
+            **Entry._total_figure_disaggregation_subquery(),
+        ).distinct()
 
 
 class BaseFigureExtractionFilterSet(df.FilterSet):
@@ -592,7 +590,7 @@ class BaseFigureExtractionFilterSet(df.FilterSet):
     def qs(self):
         # FIXME: using this prefetch_related results in calling count after a
         # subquery. This has a severe performance penalty
-        return super().qs.prefetch_related('entry__review_comments', 'context_of_violence').distinct()
+        return super().qs.distinct()
 
 
 class FigureExtractionFilterSet(BaseFigureExtractionFilterSet):


### PR DESCRIPTION
Remove unnecessary prefetch from extraction

## Changes

* Remove unnecessary prefetch from extraction

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
