### PR TITLE
Return distinct crisis when filter is applied

### DIFF
--- a/apps/crisis/filters.py
+++ b/apps/crisis/filters.py
@@ -103,4 +103,4 @@ class CrisisFilter(NameFilterMixin, django_filters.FilterSet):
                 default=None,
                 output_field=models.FloatField()
             )
-        ).prefetch_related('events')
+        ).prefetch_related('events').distinct()

--- a/apps/crisis/filters.py
+++ b/apps/crisis/filters.py
@@ -62,7 +62,7 @@ class CrisisFilter(NameFilterMixin, django_filters.FilterSet):
     def filter_created_by(self, qs, name, value):
         if not value:
             return qs
-        return qs.filter(events__created_by__in=value)
+        return qs.filter(created_by__in=value)
 
     @property
     def qs(self):


### PR DESCRIPTION
Fix crisis duplication issue

## Changes

* Fixed crisis duplication issue

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
