### PR TITLE
Add is_admin field in users

### DIFF
--- a/apps/users/tests/test_apis.py
+++ b/apps/users/tests/test_apis.py
@@ -600,7 +600,7 @@ class TestUserListSchema(HelixGraphQLTestCase):
                 totalCount
                 results {
                   id
-                  highestRole
+                  portfolioRole
                   permissions {
                     action
                   }
@@ -623,8 +623,8 @@ class TestUserListSchema(HelixGraphQLTestCase):
         self.assertEqual(content['data']['users']['totalCount'], 4)
         self.assertEqual(set([item['email'] for item in content['data']['users']['results']]),
                          set([guest.email, None]))
-        self.assertEqual(set([item['highestRole'] for item in content['data']['users']['results']]),
-                         set(['GUEST', None]))
+        self.assertEqual(set([item['portfolioRole'] for item in content['data']['users']['results']]),
+                         set([USER_ROLE.REGIONAL_COORDINATOR.name, USER_ROLE.MONITORING_EXPERT.name, None]))
         self.assertIn(
             None,
             [item['permissions'] for item in content['data']['users']['results']]
@@ -639,13 +639,6 @@ class TestUserListSchema(HelixGraphQLTestCase):
         self.assertEqual(content['data']['users']['totalCount'], 4)
         self.assertEqual(set([item['email'] for item in content['data']['users']['results']]),
                          set([ur.email, None]))
-        self.assertEqual(set([item['highestRole'] for item in content['data']['users']['results']]),
-                         set([ur.highest_role.name, None]))
-        self.assertIn(
-            None,
-            [item['permissions'] for item in content['data']['users']['results']]
-        )
-
         self.force_login(ua)
         response = self.query(
             users_q
@@ -657,11 +650,6 @@ class TestUserListSchema(HelixGraphQLTestCase):
         self.assertIn(
             None,
             [item['email'] for item in content['data']['users']['results']]
-        )
-        # we should get all roles
-        self.assertNotIn(
-            None,
-            [item['highestRole'] for item in content['data']['users']['results']]
         )
 
     def test_is_admin_field(self):


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/67

## Changes

* Add is_admin boolean field in users

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
