### PR TITLE
Upgrade staging worker memory to 2GB.

### DIFF
--- a/copilot/worker/manifest.yml
+++ b/copilot/worker/manifest.yml
@@ -45,7 +45,7 @@ secrets:
 environments:
   staging:
     cpu: 256
-    memory: 1024
+    memory: 2048
     count:
       range: 1-2
       spot_from: 1


### PR DESCRIPTION
## Changes

* Upgrade staging worker memory to 2GB.
Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations