### PR TITLE
Migrate sources and reliability in calculation logic field

### DIFF
--- a/apps/entry/management/commands/generate_sources_and_reliability_json_file.py
+++ b/apps/entry/management/commands/generate_sources_and_reliability_json_file.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+import json
+from apps.helixmigration.models import Facts
+from django.contrib.postgres.fields.jsonb import KeyTextTransform
+
+
+class Command(BaseCommand):
+    '''
+    This command requires old database connection, which is currently
+    in feature/find_bugs branch
+    '''
+
+    help = 'Migrate sources and reliability.'
+
+    def handle(self, *args, **options):
+        fact = Facts.objects.using('helixmigration').annotate(
+            sources_and_reliability=KeyTextTransform(
+                "souces", "data"
+            ),
+        )
+        out_file = open("sources_and_reliability.json", "w")
+        json.dump(
+            list(fact.filter(
+                sources_and_reliability__isnull=False
+            ).values('id', 'sources_and_reliability')),
+            out_file,
+            indent=6
+        )
+        out_file.close()

--- a/apps/entry/management/commands/migrate_sources_and_reliability.py
+++ b/apps/entry/management/commands/migrate_sources_and_reliability.py
@@ -1,0 +1,22 @@
+import requests
+from django.core.management.base import BaseCommand
+from apps.entry.models import Figure
+
+
+class Command(BaseCommand):
+    help = 'Migrate sources and reliability.'
+
+    def handle(self, *args, **options):
+        sources_and_reliability = requests.get(
+            "https://helix-copilot-staging-helix-media.s3.amazonaws.com/media/sources_and_reliability.json"
+        ).json()
+        source_and_reliability_map = {item["id"]: item['sources_and_reliability'] for item in sources_and_reliability}
+        figures = Figure.objects.filter(old_id__in=source_and_reliability_map.keys())
+        for figure in figures:
+            source_and_reliability = source_and_reliability_map.get(int(figure.old_id))
+            if source_and_reliability:
+                figure.calculation_logic = f'''
+                {figure.calculation_logic} \n\n###Source and reliability \n {source_and_reliability}
+                '''
+        Figure.objects.bulk_update(figures, ['calculation_logic', ])
+        print(f'{figures.count()} Figures updated')

--- a/apps/entry/management/commands/migrate_sources_and_reliability.py
+++ b/apps/entry/management/commands/migrate_sources_and_reliability.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             source_and_reliability = source_and_reliability_map.get(int(figure.old_id))
             if source_and_reliability:
                 figure.calculation_logic = f'''
-                {figure.calculation_logic.strip()} \n\n###Source and reliability \n {source_and_reliability}
+                {figure.calculation_logic.strip()}\n\n###Source and reliability\n{source_and_reliability}
                 '''
         Figure.objects.bulk_update(figures, ['calculation_logic', ])
         print(f'{figures.count()} Figures updated')

--- a/apps/entry/management/commands/migrate_sources_and_reliability.py
+++ b/apps/entry/management/commands/migrate_sources_and_reliability.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             source_and_reliability = source_and_reliability_map.get(int(figure.old_id))
             if source_and_reliability:
                 figure.calculation_logic = f'''
-                {figure.calculation_logic} \n\n###Source and reliability \n {source_and_reliability}
+                {figure.calculation_logic.strip()} \n\n###Source and reliability \n {source_and_reliability}
                 '''
         Figure.objects.bulk_update(figures, ['calculation_logic', ])
         print(f'{figures.count()} Figures updated')


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/162

## Changes

* Migrate sources and reliability in the calculation logic field

## To migrate data use this command
```
ocker-compose exec server python manage.py migrate_sources_and_reliability
```
- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
