### PR TITLE
Remove empty space and new line before calculation_logic

### DIFF
--- a/apps/entry/management/commands/migrate_sources_and_reliability.py
+++ b/apps/entry/management/commands/migrate_sources_and_reliability.py
@@ -15,8 +15,6 @@ class Command(BaseCommand):
         for figure in figures:
             source_and_reliability = source_and_reliability_map.get(int(figure.old_id))
             if source_and_reliability:
-                figure.calculation_logic = f'''
-                {figure.calculation_logic.strip()}\n\n###Source and reliability\n{source_and_reliability}
-                '''
+                figure.calculation_logic = f'{figure.calculation_logic.strip()}\n\n### Sources Breakdown & Reliability\n{source_and_reliability}'  # noqa: E501
         Figure.objects.bulk_update(figures, ['calculation_logic', ])
         print(f'{figures.count()} Figures updated')


### PR DESCRIPTION
- Rename "Source and reliability" to "Sources Breakdown & Reliability"
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments