### PR TITLE
Fix country code validation for osmname unsupported countries

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -499,6 +499,12 @@ class Figure(MetaInformationArchiveAbstractModel,
             models.Index(fields=['event']),
         ]
 
+    UNSUPPORTED_OSMNAME_COUNTRY_CODES = {
+        'CX', 'GP', 'BV', 'YT', 'GF', 'PR', 'AW', 'SX',
+        'SJ', 'PM', 'CW', 'HM', 'BL', 'MO', 'AX', 'GU',
+        'HK', 'NF', 'MQ', 'MF', 'CC', 'RE', 'VI'
+    }
+
     # methods
     @classmethod
     def filtered_nd_figures(

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -128,7 +128,9 @@ class CommonFigureValidationMixin:
             # If location is moved manually allow to save location of other coutries
             # These locations are considered as problematic border issues
             moved = location.get("moved", False)
-            if location.get("country_code", '').lower() != country_code.lower() and not moved:
+            if location.get('country_code', '') in Figure.UNSUPPORTED_OSMNAME_COUNTRY_CODES:
+                continue
+            elif location.get("country_code", '').lower() != country_code.lower() and not moved:
                 errors.update({
                     'geo_locations': "Location should be inside the selected figure's country"
                 })


### PR DESCRIPTION
## Changes

* Fix country code validation for osmname unsupported countries
*
Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
