### PR TITLE
Fix location missing in extraction export

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -760,7 +760,7 @@ class Figure(MetaInformationArchiveAbstractModel,
                 'geo_locations__display_name',
                 '; ',
                 filter=~Q(
-                    Q(geo_locations__city__isnull=True) | Q(geo_locations__city='')
+                    Q(geo_locations__display_name__isnull=True) | Q(geo_locations__display_name='')
                 ), distinct=True
             ),
             publishers_name=StringAgg(


### PR DESCRIPTION
Addresses
https://github.com/idmc-labs/helix2.0-meta/issues/190

## Changes

*Fix location name in figure extraction filter
Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
