### PR TITLE
Add document urls in figure export

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -810,7 +810,7 @@ class Figure(MetaInformationArchiveAbstractModel,
             entry_url_or_document_url=models.Case(
                 models.When(
                     entry__document__isnull=False,
-                    then=F('entry__document__attachment')
+                    then=F('entry__document_url')
                 ),
                 models.When(
                     entry__document__isnull=True,
@@ -872,7 +872,7 @@ class Figure(MetaInformationArchiveAbstractModel,
                 if not url:
                     return ''
                 document_name = re.findall(r"([^/]+)$", url)
-                if not document_name or document_name == url or len(document_name) == 0:
+                if len(document_name) == 0 or document_name[0] == url:
                     return ''
                 return document_name[0]
 

--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -776,7 +776,7 @@ class Figure(MetaInformationArchiveAbstractModel,
             disaggregation_location_non_camp='Location: Non-Camp',
             # Extra added fields
             old_id='Old Id',
-            entry__url='Source url',
+            entry_url_or_document_url='Source url',
             entry_link='Entry link',
             country__name='Country',
             entry__old_id='Entry Old Id',
@@ -805,6 +805,17 @@ class Figure(MetaInformationArchiveAbstractModel,
             **Figure.annotate_sources_reliability(),
             centroid_lat=Avg('geo_locations__lat'),
             centroid_lon=Avg('geo_locations__lon'),
+            entry_url_or_document_url=models.Case(
+                models.When(
+                    entry__document__isnull=False,
+                    then=F('entry__document_url')
+                ),
+                models.When(
+                    entry__document__isnull=True,
+                    then=F('entry__url')
+                ),
+                default=Value('')
+            ),
             entry_link=Concat(Value(settings.FRONTEND_BASE_URL), Value('/entries/'), F('entry__id')),
             figure_link=Concat(
                 Value(settings.FRONTEND_BASE_URL), Value('/entries/'), F('entry__id'),


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/200

## Changes

* Add document_url in figure export

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
