### PR TITLE
Add conditions to set approval-comment

### DIFF
--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -68,18 +68,18 @@ class CreateUnifiedReviewComment(graphene.Mutation):
             serialized_data = serializer.validated_data
             review_comment = serialized_data.get('comment_type')
             event = serialized_data.get('event')
-            if event and review_comment != UnifiedReviewComment.ReviewCommentType.GREY:
-                if(
-                    (not event.assignee and event.assignee == info.context.user) or
-                    (not event.assignee == info.context.user)
-                ):
-                    return UpdateUnifiedReviewComment(
-                        errors=[
-                            dict(field='nonFieldErrors',
-                                 messages=gettext('Assignee not set or permission denied'))
-                        ],
-                        ok=False
-                    )
+            if (
+                event and
+                review_comment != UnifiedReviewComment.ReviewCommentType.GREY and
+                (not event.assignee or event.assignee != info.context.user)
+            ):
+                return UpdateUnifiedReviewComment(
+                    errors=[
+                        dict(field='nonFieldErrors',
+                             messages=gettext('Assignee not set or you are not the assignee.'))
+                    ],
+                    ok=False
+                )
 
         if errors := mutation_is_not_valid(serializer):
             return CreateUnifiedReviewComment(errors=errors, ok=False)


### PR DESCRIPTION
Addresses 
https://github.com/idmc-labs/helix-server/issues/354

Depends on
https://github.com/idmc-labs/helix-server/pull/369

## Changes

* Add conditions to set approval-comments

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
