### PR TITLE
Fix/event should not change in figure update

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -989,6 +989,7 @@ class Figure(MetaInformationArchiveAbstractModel,
                 Notification.send_notification(
                     recipient=event.created_by,
                     event=event,
+                    actor=None,
                     type=Notification.Type.EVENT_APPROVED,
                 )
 

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -639,7 +639,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
     def update(self, instance, validated_data: dict) -> Entry:
         from apps.event.models import Event
 
-        def _send_notificaiton_and_update_event_status(figure, created):
+        def _send_notificaitons(figure, created):
             # FIXME This function may raise N+1 problem in mutation
             _type = None
             if figure.event and figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
@@ -662,8 +662,6 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     figure=figure,
                     event=figure.event,
                 )
-            # Update event status
-            figure.update_event_status(figure.event)
 
         figures = validated_data.pop('figures', None)
         if figures:
@@ -690,7 +688,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     fig_ser._errors = {}
                     figure = fig_ser.save()
                     if figure.event:
-                        _send_notificaiton_and_update_event_status(figure, created)
+                        _send_notificaitons(figure, created)
 
         elif isinstance(figures, list) and not figures:
             # If figure is empty list remove all figures associated with entry

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -281,6 +281,15 @@ class CommonFigureValidationMixin:
             _attrs['displacement_occurred'] = None
         return _attrs
 
+    def _validate_event(self, attrs):
+        errors = OrderedDict()
+        event = attrs.get('event')
+        if event and self.instance and self.instance.event and self.instance.event.id != event.id:
+            errors.update({
+                'event': 'Event change is not allowed'
+            })
+        return errors
+
     def validate(self, attrs: dict) -> dict:
         if not self.instance and attrs.get('id'):
             self.instance = Figure.objects.get(id=attrs['id'])
@@ -313,6 +322,7 @@ class CommonFigureValidationMixin:
         ))
         errors.update(self._validate_disaggregated_json_sum_against_total_figures(attrs, 'disaggregation_age', 'age'))
         errors.update(self._validate_figure_cause(attrs))
+        errors.update(self._validate_event(attrs))
 
         if errors:
             raise ValidationError(errors)

--- a/apps/entry/tests/test_apis.py
+++ b/apps/entry/tests/test_apis.py
@@ -742,6 +742,24 @@ class TestEntryUpdate(HelixGraphQLTestCase):
         self.assertFalse(content['data']['updateEntry']['ok'], content)
         self.assertNotIn('figureCause', json.dumps(content['data']['updateEntry']['errors']))
 
+    def test_should_not_update_event_in_figure(self):
+        self.force_login(self.admin)
+        entry = EntryFactory.create()
+        event1 = EventFactory.create()
+        event2 = EventFactory.create()
+        figure = FigureFactory.create(entry=entry, event=event1)
+        self.input['figures'] = [
+            {'id': figure.id, 'event': event2.id}
+        ]
+        response = self.query(
+            self.mutation,
+            input_data=self.input
+        )
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        self.assertFalse(content['data']['updateEntry']['ok'], content)
+        self.assertIn('event', json.dumps(content['data']['updateEntry']['errors']))
+
 
 class TestEntryDelete(HelixGraphQLTestCase):
     def setUp(self) -> None:

--- a/apps/entry/tests/test_reviews.py
+++ b/apps/entry/tests/test_reviews.py
@@ -1,11 +1,15 @@
 import json
+from uuid import uuid4
 from apps.users.enums import USER_ROLE
-from apps.entry.models import Figure
+from apps.crisis.models import Crisis
+from apps.entry.models import Figure, OSMName
 from apps.event.models import Event
 from utils.factories import (
     EventFactory,
     FigureFactory,
+    EntryFactory,
     UnifiedReviewCommentFactory,
+    CountryFactory,
 )
 from utils.tests import HelixGraphQLTestCase, create_user_with_role
 
@@ -64,8 +68,61 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
                 ok
                 }
             }'''
+        self.update_figure = """
+        mutation MyMutation($input: EntryUpdateInputType!) {
+          updateEntry(data: $input) {
+            ok
+            errors
+            result {
+              id
+              figures {
+                id
+                reviewStatus
+              }
+            }
+          }
+        }
+        """
         self.event = EventFactory.create(assigner=self.regional_coordinator, assignee=self.monitoring_expert)
         self.figure = FigureFactory.create(event=self.event)
+        self.country = CountryFactory.create()
+
+        source = dict(
+            uuid=str(uuid4()),
+            rank=101,
+            country=str(self.country.name),
+            countryCode=self.country.iso2,
+            osmId='ted',
+            osmType='okay',
+            displayName='okay',
+            lat=68.88,
+            lon=46.66,
+            name='name',
+            accuracy=OSMName.OSM_ACCURACY.ADM0.name,
+            identifier=OSMName.IDENTIFIER.ORIGIN.name
+        )
+        self.figures = [
+            {
+                "uuid": str(uuid4()),
+                "country": self.country.id,
+                "quantifier": Figure.QUANTIFIER.MORE_THAN.name,
+                "reported": 10,
+                "unit": Figure.UNIT.HOUSEHOLD.name,  # missing household_size
+                "term": Figure.FIGURE_TERMS.EVACUATED.name,
+                "category": Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.name,
+                "role": Figure.ROLE.RECOMMENDED.name,
+                "startDate": "2020-10-10",
+                "includeIdu": True,
+                "excerptIdu": "excerpt abc",
+                "figureCause": Crisis.CRISIS_TYPE.CONFLICT.name,
+                "geoLocations": [source],
+                "householdSize": 20,
+                "tags": [],
+                "contextOfViolence": [],
+                "sources": [],
+            }
+
+        ]
 
     def test_all_users_can_approve_figure_except_guest(self) -> None:
         users = [self.admin, self.monitoring_expert, self.regional_coordinator]
@@ -206,3 +263,56 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
 
         event.refresh_from_db()
         self.assertEqual(event.review_status, event.EVENT_REVIEW_STATUS.REVIEW_NOT_STARTED)
+
+    def test_should_change_figure_status_in_progress_if_figure_is_saved(self):
+        entry = EntryFactory.create()
+        event = EventFactory.create(
+            assigner=self.regional_coordinator,
+            assignee=self.regional_coordinator,
+            review_status=Event.EVENT_REVIEW_STATUS.APPROVED,
+            countries=[self.country],
+        )
+        figure = FigureFactory.create(
+            entry=entry,
+            review_status=Figure.FIGURE_REVIEW_STATUS.APPROVED,
+            event=event,
+            country=self.country,
+        )
+        figures = self.figures
+        figures[0]['event'] = event.id
+        figures[0]['country'] = self.country.id
+        figures[0]['id'] = figure.id
+
+        # No review comment case on figure
+        self.force_login(self.regional_coordinator)
+        response = self.query(
+            self.update_figure,
+            input_data={
+                'id': entry.id,
+                'figures': figures
+            }
+        )
+        content = json.loads(response.content)
+        figure_id = content['data']['updateEntry']['result']['figures'][0]['id']
+        review_status = content['data']['updateEntry']['result']['figures'][0]['reviewStatus']
+        self.assertEqual(str(figure.id), figure_id)
+        self.assertEqual(Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED.name, review_status)
+
+        # Create a review comment on figure
+        UnifiedReviewCommentFactory.create(figure=figure, event=event, comment='test comment')
+
+        figure.refresh_from_db()
+        # Review comment on figure case
+        self.force_login(self.regional_coordinator)
+        response = self.query(
+            self.update_figure,
+            input_data={
+                'id': entry.id,
+                'figures': figures
+            }
+        )
+        content = json.loads(response.content)
+        figure_id = content['data']['updateEntry']['result']['figures'][0]['id']
+        review_status = content['data']['updateEntry']['result']['figures'][0]['reviewStatus']
+        self.assertEqual(str(figure.id), figure_id)
+        self.assertEqual(Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS.name, review_status)

--- a/apps/event/mutations.py
+++ b/apps/event/mutations.py
@@ -515,6 +515,9 @@ class SignOffEvent(graphene.Mutation):
         event.review_status = Event.EVENT_REVIEW_STATUS.SIGNED_OFF
         event.save()
 
+        # Refresh event
+        event.refresh_from_db()
+
         # Update event status
         Figure.update_event_status(event)
 
@@ -527,6 +530,14 @@ class SignOffEvent(graphene.Mutation):
                 actor=info.context.user,
                 event=event,
             )
+        if event.created_by:
+            Notification.send_notification(
+                recipient=event.created_by,
+                type=Notification.Type.EVENT_SIGNED_OFF,
+                actor=info.context.user,
+                event=event,
+            )
+
         return SignOffEvent(result=event, errors=None, ok=True)
 
 

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -194,7 +194,6 @@ class EventSerializer(MetaInformationSerializerMixin,
             new_include_triangulation_in_qa = validated_data.get('include_triangulation_in_qa')
             if new_include_triangulation_in_qa != instance.include_triangulation_in_qa:
                 is_include_triangulation_in_qa_changed = True
-                Figure.update_event_status(instance)
                 Notification.send_multiple_notifications(
                     recipients=instance.regional_coordinators(
                         event=instance

--- a/apps/extraction/tests/test_filters.py
+++ b/apps/extraction/tests/test_filters.py
@@ -262,7 +262,7 @@ class TestExtractionFilter(HelixTestCase):
             filter_figure_categories=[self.fig_cat2]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1})
 
     def test_filter_by_category_types(self):
         data = dict(

--- a/apps/notification/tests/test_notifications.py
+++ b/apps/notification/tests/test_notifications.py
@@ -515,7 +515,11 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
             countries=(self.country, ),
             created_by=self.admin,
         )
-        figure = FigureFactory.create(event=event, review_status=Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS)
+        figure = FigureFactory.create(
+            event=event,
+            country=self.country,
+            review_status=Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+        )
         self.force_login(self.monitoring_expert)
         self.query(
             self.approve_figure,

--- a/apps/notification/tests/test_notifications.py
+++ b/apps/notification/tests/test_notifications.py
@@ -527,7 +527,8 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
         figure = FigureFactory.create(
             event=event,
             country=self.country,
-            review_status=Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+            review_status=Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS,
+            role=Figure.ROLE.RECOMMENDED,
         )
         self.force_login(self.monitoring_expert)
         self.query(

--- a/apps/notification/tests/test_notifications.py
+++ b/apps/notification/tests/test_notifications.py
@@ -8,6 +8,8 @@ from utils.factories import (
     CountryFactory,
     MonitoringSubRegionFactory,
     NotificationFactory,
+    CountryRegionFactory,
+    CountrySubRegionFactory,
 )
 from apps.notification.models import Notification
 from utils.tests import HelixGraphQLTestCase, create_user_with_role
@@ -19,8 +21,15 @@ from apps.review.models import UnifiedReviewComment
 
 class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
     def setUp(self) -> None:
-        self.country = CountryFactory.create()
+        self.region = CountryRegionFactory.create()
+        self.sub_region = CountrySubRegionFactory.create()
         self.monitoring_sub_region = MonitoringSubRegionFactory.create()
+
+        self.country = CountryFactory.create(
+            monitoring_sub_region=self.monitoring_sub_region,
+            region=self.region,
+            sub_region=self.sub_region,
+        )
         self.regional_coordinator = create_user_with_role(
             USER_ROLE.REGIONAL_COORDINATOR.name,
             country=self.country.id,

--- a/utils/factories.py
+++ b/utils/factories.py
@@ -24,6 +24,13 @@ class GeographicalGroupFactory(DjangoModelFactory):
     name = factory.Faker('first_name')
 
 
+class CountrySubRegionFactory(DjangoModelFactory):
+    class Meta:
+        model = 'country.CountrySubRegion'
+
+    name = factory.Faker('first_name')
+
+
 class MonitoringSubRegionFactory(DjangoModelFactory):
     class Meta:
         model = 'country.MonitoringSubRegion'


### PR DESCRIPTION
Addresses 
https://github.com/idmc-labs/helix-server/issues/400
https://github.com/idmc-labs/helix-server/issues/402
https://github.com/idmc-labs/helix-server/issues/403
https://github.com/idmc-labs/helix-server/issues/404

## Changes

* Add validation for the event should not change in figure update
* Update figure status to review_in_progress if figure saved and has review comments
* Update figure status to  review_not_started  if figure saved and has no review comments

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
