### PR TITLE
Refactor notifications and test-cases

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -957,11 +957,9 @@ class Figure(MetaInformationArchiveAbstractModel,
     @classmethod
     def update_figure_status(cls, figure):
         # Change figure status
-        figure.review_status = (
-            Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
-            if figure.figure_review_comments.count() > 0
-            else Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
-        )
+        figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
+        if figure.figure_review_comments.count() > 0:
+            figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
         figure.save()
 
     # TODO: move this to event model

--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -966,12 +966,12 @@ class Figure(MetaInformationArchiveAbstractModel,
 
     # TODO: move this to event model
     @classmethod
-    def update_event_status_and_send_notifications(cls, event):
+    def update_event_status_and_send_notifications(cls, event_id):
         from apps.event.models import Event
 
         # FIXME: should we directly get event_id from the args instead?
         event_with_stats = Event.objects.filter(
-            id=event.id
+            id=event_id
         ).annotate(
             **Event.annotate_review_figures_count()
         ).first()

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -1,6 +1,5 @@
 from django.utils.translation import gettext
 import graphene
-from django.utils.translation import gettext_lazy as _
 from graphene_django.filter.utils import get_filtering_args_from_filterset
 from django.utils import timezone
 

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -321,7 +321,7 @@ class DeleteFigure(graphene.Mutation):
                 event=instance.event,
             )
 
-        Figure.update_event_status_and_send_notifications(instance.event.id)
+        Figure.update_event_status_and_send_notifications(instance.event_id)
         instance.event.refresh_from_db()
 
         return DeleteFigure(errors=None, ok=True)
@@ -355,7 +355,7 @@ class ApproveFigure(graphene.Mutation):
 
         # NOTE: not sending notification when figure is approved as it is not actionable
 
-        Figure.update_event_status_and_send_notifications(figure.event.id)
+        Figure.update_event_status_and_send_notifications(figure.event_id)
         figure.event.refresh_from_db()
 
         return ApproveFigure(result=figure, errors=None, ok=True)
@@ -415,7 +415,7 @@ class UnapproveFigure(graphene.Mutation):
             )
 
         # Update event status
-        Figure.update_event_status_and_send_notifications(figure.event.id)
+        Figure.update_event_status_and_send_notifications(figure.event_id)
         figure.event.refresh_from_db()
 
         return UnapproveFigure(result=figure, errors=None, ok=True)
@@ -458,7 +458,7 @@ class ReRequestReviewFigure(graphene.Mutation):
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,
             )
 
-        Figure.update_event_status_and_send_notifications(figure.event.id)
+        Figure.update_event_status_and_send_notifications(figure.event_id)
         figure.event.refresh_from_db()
 
         return ReRequestReviewFigure(result=figure, errors=None, ok=True)

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -454,7 +454,7 @@ class ReRequestReviewFigure(graphene.Mutation):
             Notification.send_safe_multiple_notifications(
                 event=figure.event,
                 figure=figure,
-                recipients=[figure.event.assignee.id],
+                recipients=[figure.event.assignee_id],
                 actor=info.context.user,
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,
             )

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -312,7 +312,7 @@ class DeleteFigure(graphene.Mutation):
         if _type:
             recipients = [user['id'] for user in Event.regional_coordinators(
                 instance.event,
-                figure=instance,
+                actor=info.context.user,
             )]
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,
@@ -322,7 +322,7 @@ class DeleteFigure(graphene.Mutation):
                 event=instance.event,
             )
 
-        Figure.update_event_status_and_send_notifications(instance.event)
+        Figure.update_event_status_and_send_notifications(instance.event.id)
         instance.event.refresh_from_db()
 
         return DeleteFigure(errors=None, ok=True)
@@ -356,7 +356,7 @@ class ApproveFigure(graphene.Mutation):
 
         # NOTE: not sending notification when figure is approved as it is not actionable
 
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return ApproveFigure(result=figure, errors=None, ok=True)
@@ -405,7 +405,7 @@ class UnapproveFigure(graphene.Mutation):
         if _type:
             recipients = [user['id'] for user in Event.regional_coordinators(
                 figure.event,
-                figure=figure,
+                actor=info.context.user,
             )]
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,
@@ -416,7 +416,7 @@ class UnapproveFigure(graphene.Mutation):
             )
 
         # Update event status
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return UnapproveFigure(result=figure, errors=None, ok=True)
@@ -459,7 +459,7 @@ class ReRequestReviewFigure(graphene.Mutation):
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,
             )
 
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return ReRequestReviewFigure(result=figure, errors=None, ok=True)

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -109,77 +109,6 @@ class DeleteEntry(graphene.Mutation):
         return DeleteEntry(result=instance, errors=None, ok=True)
 
 
-class updateFigure(graphene.Mutation):
-
-    class Arguments:
-        data = FigureUpdateInputType(required=True)
-
-    errors = graphene.List(graphene.NonNull(CustomErrorType))
-    ok = graphene.Boolean()
-    result = graphene.Field(EntryType)
-
-    @staticmethod
-    @permission_checker(['entry.change_figure'])
-    def mutate(root, info, data):
-        try:
-            instance = Figure.objects.get(id=data['id'])
-        except Entry.DoesNotExist:
-            return updateFigure(errors=[
-                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
-            ])
-        serializer = NestedFigureUpdateSerializer(
-            instance=instance, data=data,
-            context={'request': info.context.request}, partial=True
-        )
-        if errors := mutation_is_not_valid(serializer):
-            return updateFigure(errors=errors, ok=False)
-        instance = serializer.save()
-        return updateFigure(result=instance, errors=None, ok=True)
-
-
-class DeleteFigure(graphene.Mutation):
-    from apps.event.models import Event
-
-    class Arguments:
-        id = graphene.ID(required=True)
-
-    errors = graphene.List(graphene.NonNull(CustomErrorType))
-    ok = graphene.Boolean()
-    result = graphene.Field(FigureType)
-
-    @staticmethod
-    @permission_checker(['entry.delete_figure'])
-    def mutate(root, info, id):
-        from apps.event.models import Event
-
-        try:
-            instance = Figure.objects.get(id=id)
-        except Entry.DoesNotExist:
-            return DeleteFigure(errors=[
-                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
-            ])
-
-        if instance.event:
-            _type = None
-            if instance.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
-                _type = Notification.Type.FIGURE_DELETED_IN_APPROVED_EVENT
-            if instance.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
-                _type = Notification.Type.FIGURE_DELETED_IN_SIGNED_EVENT
-            if _type:
-                Notification.send_multiple_notifications(
-                    recipients=instance.event.regional_coordinators(
-                        event=instance.event
-                    ),
-                    actor=info.context.user,
-                    type=_type,
-                    entry=instance.entry,
-                    event=instance.event,
-                    text=_('Figure was deleted'),
-                )
-        instance.delete()
-        return DeleteFigure(errors=None, ok=True)
-
-
 SourcePreviewInputType = generate_input_type_for_serializer(
     'SourcePreviewInputType',
     SourcePreviewSerializer
@@ -223,7 +152,6 @@ FigureTagCreateInputType = generate_input_type_for_serializer(
     'FigureTagCreateInputType',
     FigureTagCreateSerializer
 )
-
 
 FigureTagUpdateInputType = generate_input_type_for_serializer(
     'FigureTagUpdateInputType',
@@ -350,6 +278,56 @@ class ExportFigures(graphene.Mutation):
         return ExportFigures(errors=None, ok=True)
 
 
+class DeleteFigure(graphene.Mutation):
+    class Arguments:
+        id = graphene.ID(required=True)
+
+    errors = graphene.List(graphene.NonNull(CustomErrorType))
+    ok = graphene.Boolean()
+    result = graphene.Field(FigureType)
+
+    @staticmethod
+    @permission_checker(['entry.delete_figure'])
+    def mutate(root, info, id):
+        from apps.event.models import Event
+
+        try:
+            instance = Figure.objects.get(id=id)
+        except Entry.DoesNotExist:
+            return DeleteFigure(errors=[
+                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
+            ])
+
+        instance.delete()
+
+        def _get_notification_type(event):
+            if event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
+                return Notification.Type.FIGURE_DELETED_IN_APPROVED_EVENT
+            if event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
+                return Notification.Type.FIGURE_DELETED_IN_SIGNED_EVENT
+            return None
+
+        _type = _get_notification_type(instance.event)
+
+        if _type:
+            recipients = [user['id'] for user in Event.regional_coordinators(
+                instance.event,
+                figure=instance,
+            )]
+            Notification.send_safe_multiple_notifications(
+                recipients=recipients,
+                actor=info.context.user,
+                type=_type,
+                entry=instance.entry,
+                event=instance.event,
+            )
+
+        Figure.update_event_status_and_send_notifications(instance.event)
+        instance.event.refresh_from_db()
+
+        return DeleteFigure(errors=None, ok=True)
+
+
 class ApproveFigure(graphene.Mutation):
     class Arguments:
         id = graphene.ID(required=True)
@@ -364,17 +342,23 @@ class ApproveFigure(graphene.Mutation):
         figure = Figure.objects.filter(id=id).first()
         if not figure:
             return ApproveFigure(errors=[
-                dict(field='id', messages=gettext('Figure does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
             ])
+        if figure.review_status == Figure.FIGURE_REVIEW_STATUS.APPROVED:
+            return ApproveFigure(errors=[
+                dict(field='nonFieldErrors', messages=gettext('Approved figures cannot be approved'))
+            ])
+
         figure.review_status = Figure.FIGURE_REVIEW_STATUS.APPROVED.value
         figure.approved_by = info.context.user
         figure.approved_on = timezone.now()
         figure.save()
-        if figure.event:
-            figure.update_event_status(figure.event)
-        # NOTE: Event is updated on figure save using signals.
-        # We are clearing figure and its reference objects (event).
-        figure.refresh_from_db()
+
+        # NOTE: not sending notification when figure is approved as it is not actionable
+
+        Figure.update_event_status_and_send_notifications(figure.event)
+        figure.event.refresh_from_db()
+
         return ApproveFigure(result=figure, errors=None, ok=True)
 
 
@@ -394,42 +378,51 @@ class UnapproveFigure(graphene.Mutation):
         figure = Figure.objects.filter(id=id).first()
         if not figure:
             return UnapproveFigure(errors=[
-                dict(field='id', messages=gettext('Figure does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
             ])
-        figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
-        if figure.figure_review_comments.all().count() > 0:
-            figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+        if figure.review_status != Figure.FIGURE_REVIEW_STATUS.APPROVED:
+            return UnapproveFigure(errors=[
+                dict(field='nonFieldErrors', messages=gettext('Only approved figures can be un-approved'))
+            ])
+
+        figure.review_status = (
+            Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+            if figure.figure_review_comments.all().count() > 0
+            else Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
+        )
         figure.approved_by = None
         figure.approved_on = None
         figure.save()
 
-        if figure.event:
-            # Update event status
-            figure.update_event_status(figure.event)
+        def _get_notification_type(event):
+            if event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
+                return Notification.Type.FIGURE_UNAPPROVED_IN_APPROVED_EVENT
+            if event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
+                return Notification.Type.FIGURE_UNAPPROVED_IN_SIGNED_EVENT
+            return None
 
-            _type = None
-            if figure.event and figure.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
-                _type = Notification.Type.FIGURE_UNAPPROVED_IN_APPROVED_EVENT
-            if figure.event and figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
-                _type = Notification.Type.FIGURE_UNAPPROVED_IN_SIGNED_EVENT
-            if _type:
-                Notification.send_multiple_notifications(
-                    recipients=figure.event.regional_coordinators(
-                        event=figure.event,
-                        figure=figure,
-                    ),
-                    type=_type,
-                    actor=info.context.user,
-                    event=figure.event,
-                    figure=figure,
-                )
-        # NOTE: Event is updated on figure save using signals.
-        # We are clearing figure and its reference objects (event).
-        figure.refresh_from_db()
+        _type = _get_notification_type(figure.event)
+        if _type:
+            recipients = [user['id'] for user in Event.regional_coordinators(
+                figure.event,
+                figure=figure,
+            )]
+            Notification.send_safe_multiple_notifications(
+                recipients=recipients,
+                type=_type,
+                actor=info.context.user,
+                event=figure.event,
+                figure=figure,
+            )
+
+        # Update event status
+        Figure.update_event_status_and_send_notifications(figure.event)
+        figure.event.refresh_from_db()
+
         return UnapproveFigure(result=figure, errors=None, ok=True)
 
 
-class ReRequestReivewFigure(graphene.Mutation):
+class ReRequestReviewFigure(graphene.Mutation):
     class Arguments:
         id = graphene.ID(required=True)
 
@@ -443,35 +436,40 @@ class ReRequestReivewFigure(graphene.Mutation):
     def mutate(root, info, id):
         figure = Figure.objects.filter(id=id).first()
         if not figure:
-            return ReRequestReivewFigure(errors=[
-                dict(field='id', messages=gettext('Figure does not exist.'))
+            return ReRequestReviewFigure(errors=[
+                dict(field='nonFieldErrors', messages=gettext('Figure does not exist.'))
             ])
+
+        if figure.review_status != Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS:
+            return ReRequestReviewFigure(errors=[
+                dict(field='nonFieldErrors', messages=gettext('Only in-progress figures can be re-requested review'))
+            ])
+
         figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_RE_REQUESTED
         figure.approved_by = None
         figure.approved_on = None
         figure.save()
 
-        if figure.event:
-            figure.update_event_status(figure.event)
-
-        # NOTE: Event is updated on figure save using signals.
-        # We are clearing figure and its reference objects (event).
-        figure.refresh_from_db()
-
-        if figure.event and figure.event.assignee:
-            Notification.send_notification(
+        if figure.event.assignee:
+            Notification.send_safe_multiple_notifications(
                 event=figure.event,
-                recipient=figure.event.assignee,
+                figure=figure,
+                recipients=[figure.event.assignee.id],
                 actor=info.context.user,
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,
             )
-        return ReRequestReivewFigure(result=figure, errors=None, ok=True)
+
+        Figure.update_event_status_and_send_notifications(figure.event)
+        figure.event.refresh_from_db()
+
+        return ReRequestReviewFigure(result=figure, errors=None, ok=True)
 
 
 class Mutation(object):
     create_entry = CreateEntry.Field()
     update_entry = UpdateEntry.Field()
     delete_entry = DeleteEntry.Field()
+    # source preview
     create_source_preview = CreateSourcePreview.Field()
     # figure tags
     create_figure_tag = CreateFigureTag.Field()
@@ -481,9 +479,7 @@ class Mutation(object):
     export_entries = ExportEntries.Field()
     export_figures = ExportFigures.Field()
     # figure
-    update_figure = updateFigure.Field()
     delete_figure = DeleteFigure.Field()
-    # figure reviews
     approve_figure = ApproveFigure.Field()
     unapprove_figure = UnapproveFigure.Field()
-    re_request_review_figure = ReRequestReivewFigure.Field()
+    re_request_review_figure = ReRequestReviewFigure.Field()

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -657,14 +657,14 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                 figures_to_delete = entry.figures.exclude(
                     id__in=[each['id'] for each in figures if each.get('id')]
                 )
-
-                deleted_figures_for_signed_off_events = figures_to_delete.filter(
-                    event__review_status=Event.EVENT_REVIEW_STATUS.SIGNED_OFF
+                deleted_figures_for_signed_off_events = list(
+                    figures_to_delete.filter(
+                    event__review_status=Event.EVENT_REVIEW_STATUS.SIGNED_OFF)
                 )
-                deleted_figures_for_approved_events = figures_to_delete.filter(
-                    event__review_status=Event.EVENT_REVIEW_STATUS.APPROVED
+                deleted_figures_for_approved_events = list(
+                    figures_to_delete.filter(
+                    event__review_status=Event.EVENT_REVIEW_STATUS.APPROVED)
                 )
-
                 affected_events = Event.objects.filter(
                     id__in=figures_to_delete.values('event__id')
                 ).distinct('id')
@@ -777,11 +777,9 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         event=figure.event,
                         figure=figure,
                     )
-
-                for event in Event.objects.filter(id__in=affected_event_ids):
-                    Figure.update_event_status_and_send_notifications(event.id)
-
-            instance.refresh_from_db()
+                for event_id in affected_event_ids:
+                    Figure.update_event_status_and_send_notifications(event_id)
+        instance.refresh_from_db()
         return instance
 
 

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -668,11 +668,9 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     event__review_status=Event.EVENT_REVIEW_STATUS.APPROVED
                 )
 
-                affected_events = Event.objects.none()
-                if figures_to_delete:
-                    affected_events = Event.objects.filter(
-                        id=figures_to_delete
-                    ).distinct('id')
+                affected_events = Event.objects.filter(
+                    id__in=figures_to_delete.values('event__id')
+                ).distinct('id')
 
                 for each in figures:
                     is_new_figure = not each.get('id')

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -659,11 +659,13 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                 )
                 deleted_figures_for_signed_off_events = list(
                     figures_to_delete.filter(
-                    event__review_status=Event.EVENT_REVIEW_STATUS.SIGNED_OFF)
+                        event__review_status=Event.EVENT_REVIEW_STATUS.SIGNED_OFF
+                    )
                 )
                 deleted_figures_for_approved_events = list(
                     figures_to_delete.filter(
-                    event__review_status=Event.EVENT_REVIEW_STATUS.APPROVED)
+                        event__review_status=Event.EVENT_REVIEW_STATUS.APPROVED
+                    )
                 )
                 affected_events = Event.objects.filter(
                     id__in=figures_to_delete.values('event__id')

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -284,7 +284,7 @@ class CommonFigureValidationMixin:
     def _validate_event(self, attrs):
         errors = OrderedDict()
         event = attrs.get('event')
-        if event and self.instance and self.instance.event and self.instance.event.id != event.id:
+        if event and self.instance and self.instance.event and self.instance.event_id != event.id:
             errors.update({
                 'event': 'Event change is not allowed'
             })

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -639,71 +639,149 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
     def update(self, instance, validated_data: dict) -> Entry:
         from apps.event.models import Event
 
-        def _send_notificaitons_and_update_status(figure, created):
-            # FIXME This function may raise N+1 problem in mutation
-            _type = None
-            if figure.event and figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
-                _type = (
-                    Notification.Type.FIGURE_CREATED_IN_SIGNED_EVENT
-                    if created
-                    else Notification.Type.FIGURE_UPDATED_IN_SIGNED_EVENT
-                )
-            if figure.event and figure.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
-                _type = (
-                    Notification.Type.FIGURE_CREATED_IN_APPROVED_EVENT
-                    if created
-                    else Notification.Type.FIGURE_UPDATED_IN_APPROVED_EVENT
-                )
-            if _type:
-                Notification.send_multiple_notifications(
-                    recipients=figure.event.regional_coordinators(figure.event, figure=figure),
-                    actor=self.context['request'].user,
-                    type=_type,
-                    figure=figure,
-                    event=figure.event,
-                )
-
-            # Change figure status
-            if figure.figure_review_comments.count() > 0:
-                figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
-            else:
-                figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
-            figure.save()
-
-            # Update event status
-            if figure.event:
-                Figure.update_event_status(figure.event)
-
         figures = validated_data.pop('figures', None)
-        if figures:
+
+        if isinstance(figures, list):
             with transaction.atomic():
+                deleted_figures_for_signed_off_events = []
+                deleted_figures_for_approved_events = []
+
+                created_figures_for_signed_off_events = []
+                created_figures_for_approved_events = []
+
+                updated_figures_for_signed_off_events = []
+                updated_figures_for_approved_events = []
+                updated_figures_for_other_events = []
+
+                affected_events = []
+
                 entry = super().update(instance, validated_data)
+
                 # delete missing figures
-                entry.figures.exclude(
-                    id__in=[each['id'] for each in figures if each.get('id')]).delete()
-                # create if has no ids
-                created = False
+                figures_to_delete = entry.figures.exclude(
+                    id__in=[each['id'] for each in figures if each.get('id')]
+                )
+                figures_to_delete.delete()
+
+                deleted_figures_for_signed_off_events.extend([
+                    figure
+                    for figure in figures_to_delete
+                    if figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF
+                ])
+                deleted_figures_for_approved_events.extend([
+                    figure
+                    for figure in figures_to_delete
+                    if figure.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED
+                ])
+
+                affected_events.extend([
+                    figure.event for figure in figures_to_delete
+                ])
+
                 for each in figures:
+                    is_new_figure = not each.get('id')
+                    # create new figures
                     if not each.get('id'):
-                        created = True
                         fig_ser = NestedFigureCreateSerializer(context=self.context)
-                        fig_ser._validated_data = {**each, 'entry': entry}
+                    # update existing figures
                     else:
-                        created = False
                         fig_ser = NestedFigureUpdateSerializer(
                             instance=entry.figures.get(id=each['id']),
                             partial=True,
                             context=self.context,
                         )
-                        fig_ser._validated_data = {**each, 'entry': entry}
+
+                    fig_ser._validated_data = {**each, 'entry': entry}
                     fig_ser._errors = {}
                     figure = fig_ser.save()
-                    if figure.event:
-                        _send_notificaitons_and_update_status(figure, created)
 
-        elif isinstance(figures, list) and not figures:
-            # If figure is empty list remove all figures associated with entry
-            Figure.objects.filter(entry=instance).delete()
+                    if is_new_figure and figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
+                        created_figures_for_signed_off_events.append(
+                            figure
+                        )
+                    elif is_new_figure and figure.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
+                        created_figures_for_approved_events.append(
+                            figure
+                        )
+                    elif not is_new_figure and figure.event.review_status == Event.EVENT_REVIEW_STATUS.SIGNED_OFF:
+                        updated_figures_for_signed_off_events.append(
+                            figure
+                        )
+                    elif not is_new_figure and figure.event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
+                        updated_figures_for_approved_events.append(
+                            figure
+                        )
+                    elif not is_new_figure:
+                        updated_figures_for_other_events.append(
+                            figure
+                        )
+
+                    affected_events.append(figure.event)
+
+                for figure in deleted_figures_for_signed_off_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_DELETED_IN_SIGNED_EVENT,
+                        event=figure.event,
+                    )
+                for figure in deleted_figures_for_approved_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_DELETED_IN_APPROVED_EVENT,
+                        event=figure.event,
+                    )
+                for figure in updated_figures_for_signed_off_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_UPDATED_IN_SIGNED_EVENT,
+                        event=figure.event,
+                        figure=figure,
+                    )
+                    Figure.update_figure_status(figure)
+                    figure.refresh_from_db()
+                for figure in updated_figures_for_approved_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_UPDATED_IN_APPROVED_EVENT,
+                        event=figure.event,
+                        figure=figure,
+                    )
+                    Figure.update_figure_status(figure)
+                    figure.refresh_from_db()
+                for figure in updated_figures_for_other_events:
+                    Figure.update_figure_status(figure)
+                    figure.refresh_from_db()
+                for figure in created_figures_for_signed_off_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_CREATED_IN_SIGNED_EVENT,
+                        event=figure.event,
+                        figure=figure,
+                    )
+                for figure in created_figures_for_approved_events:
+                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    Notification.send_safe_multiple_notifications(
+                        recipients=recipients,
+                        actor=self.context['request'].user,
+                        type=Notification.Type.FIGURE_CREATED_IN_APPROVED_EVENT,
+                        event=figure.event,
+                        figure=figure,
+                    )
+
+                # FIXME: check if unique works
+                for event in list(set(affected_events)):
+                    Figure.update_event_status_and_send_notifications(event)
+                    event.refresh_from_db()
 
         entry = super().update(instance, validated_data)
         return entry

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -719,7 +719,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     affected_events.append(figure.event)
 
                 for figure in deleted_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -727,7 +730,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         event=figure.event,
                     )
                 for figure in deleted_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -735,7 +741,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         event=figure.event,
                     )
                 for figure in updated_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -746,7 +755,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     Figure.update_figure_status(figure)
                     figure.refresh_from_db()
                 for figure in updated_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -760,7 +772,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     Figure.update_figure_status(figure)
                     figure.refresh_from_db()
                 for figure in created_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -769,7 +784,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         figure=figure,
                     )
                 for figure in created_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -780,7 +798,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
 
                 # FIXME: check if unique works
                 for event in list(set(affected_events)):
-                    Figure.update_event_status_and_send_notifications(event)
+                    Figure.update_event_status_and_send_notifications(event.id)
                     event.refresh_from_db()
 
         entry = super().update(instance, validated_data)

--- a/apps/event/models.py
+++ b/apps/event/models.py
@@ -331,9 +331,9 @@ class Event(MetaInformationArchiveAbstractModel, models.Model):
             )
         }
 
+    # FIXME: this is wrong, this should see event and user not event and figure
     @staticmethod
     def regional_coordinators(event, figure=None):
-
         figure_regional_coordinators = User.objects.none()
         event_regional_coordinators = User.objects.none()
 

--- a/apps/event/models.py
+++ b/apps/event/models.py
@@ -333,14 +333,16 @@ class Event(MetaInformationArchiveAbstractModel, models.Model):
 
     # FIXME: this is wrong, this should see event and user not event and figure
     @staticmethod
-    def regional_coordinators(event, figure=None):
-        figure_regional_coordinators = User.objects.none()
+    def regional_coordinators(event, actor=None):
+        actor_regional_coordinators = User.objects.none()
         event_regional_coordinators = User.objects.none()
 
-        if figure and figure.country:
-            figure_regional_coordinators = User.objects.filter(
+        if actor:
+            actor_regional_coordinators = User.objects.filter(
                 portfolios__role=USER_ROLE.REGIONAL_COORDINATOR,
-                portfolios__country=figure.country
+                portfolios__country__in=actor.portfolios.values(
+                    'country'
+                )
             )
 
         if event.countries:
@@ -350,7 +352,7 @@ class Event(MetaInformationArchiveAbstractModel, models.Model):
                     'portfolio__monitoring_sub_region'
                 )
             )
-        coordinators = figure_regional_coordinators | event_regional_coordinators
+        coordinators = actor_regional_coordinators | event_regional_coordinators
         return coordinators.values('id')
 
     @classmethod

--- a/apps/event/mutations.py
+++ b/apps/event/mutations.py
@@ -384,7 +384,7 @@ class SetAssigneeToEvent(graphene.Mutation):
         )
 
         # Update event status
-        Figure.update_event_status_and_send_notifications(event)
+        Figure.update_event_status_and_send_notifications(event.id)
         event.refresh_from_db()
 
         return SetAssigneeToEvent(result=event, errors=None, ok=True)
@@ -411,7 +411,10 @@ class SetSelfAssigneeToEvent(graphene.Mutation):
         event.assigned_at = timezone.now()
         event.save()
 
-        recipients = [user['id'] for user in Event.regional_coordinators(event)]
+        recipients = [user['id'] for user in Event.regional_coordinators(
+            event,
+            actor=info.context.user,
+        )]
         Notification.send_safe_multiple_notifications(
             recipients=recipients,
             type=Notification.Type.EVENT_SELF_ASSIGNED,
@@ -419,7 +422,7 @@ class SetSelfAssigneeToEvent(graphene.Mutation):
             event=event,
         )
 
-        Figure.update_event_status_and_send_notifications(event)
+        Figure.update_event_status_and_send_notifications(event.id)
         event.refresh_from_db()
 
         return SetSelfAssigneeToEvent(result=event, errors=None, ok=True)
@@ -464,7 +467,7 @@ class ClearAssigneFromEvent(graphene.Mutation):
                 type=Notification.Type.EVENT_ASSIGNEE_CLEARED,
             )
 
-        Figure.update_event_status_and_send_notifications(event)
+        Figure.update_event_status_and_send_notifications(event.id)
         event.refresh_from_db()
 
         return ClearAssigneFromEvent(result=event, errors=None, ok=True)
@@ -499,7 +502,10 @@ class ClearSelfAssigneFromEvent(graphene.Mutation):
         event.save()
 
         if event.regional_coordinators:
-            recipients = [user['id'] for user in Event.regional_coordinators(event)]
+            recipients = [user['id'] for user in Event.regional_coordinators(
+                event,
+                actor=info.context.user,
+            )]
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,
                 type=Notification.Type.EVENT_ASSIGNEE_CLEARED,
@@ -507,7 +513,7 @@ class ClearSelfAssigneFromEvent(graphene.Mutation):
                 event=event,
             )
 
-        Figure.update_event_status_and_send_notifications(event)
+        Figure.update_event_status_and_send_notifications(event.id)
         event.refresh_from_db()
 
         return ClearSelfAssigneFromEvent(result=event, errors=None, ok=True)
@@ -539,6 +545,7 @@ class SignOffEvent(graphene.Mutation):
         recipients = [user['id'] for user in Event.regional_coordinators(event)]
         if event.created_by_id:
             recipients.append(event.created_by_id)
+
         Notification.send_safe_multiple_notifications(
             recipients=recipients,
             type=Notification.Type.EVENT_SIGNED_OFF,

--- a/apps/event/mutations.py
+++ b/apps/event/mutations.py
@@ -352,14 +352,14 @@ class SetAssigneeToEvent(graphene.Mutation):
         event = Event.objects.filter(id=event_id).first()
         if not event:
             return SetAssigneeToEvent(errors=[
-                dict(field='event_id', messages=gettext('Event does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Event does not exist.'))
             ])
 
         user = User.objects.filter(id=user_id).first()
         # To prevent users being saved with no permission in event review process. for eg GUEST
         if not user.has_perm('event.self_assign_event'):
             return SetAssigneeToEvent(errors=[
-                dict(field='user_id', messages=gettext('The user does not exist or has enough permissions.'))
+                dict(field='nonFieldErrors', messages=gettext('The user does not exist or has enough permissions.'))
             ])
 
         prev_assignee_id = event.assignee_id
@@ -403,7 +403,7 @@ class SetSelfAssigneeToEvent(graphene.Mutation):
         event = Event.objects.filter(id=event_id).first()
         if not event:
             return SetSelfAssigneeToEvent(errors=[
-                dict(field='event_id', messages=gettext('Event does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Event does not exist.'))
             ])
 
         event.assignee = info.context.user
@@ -439,12 +439,17 @@ class ClearAssigneFromEvent(graphene.Mutation):
         event = Event.objects.filter(id=event_id).first()
         if not event:
             return ClearAssigneFromEvent(errors=[
-                dict(field='event_id', messages=gettext('Event does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Event does not exist.'))
             ])
 
-        # FIXME: throw error if there is not prev_assignee
-
         prev_assignee_id = event.assignee_id
+        if not prev_assignee_id:
+            return ClearAssigneFromEvent(errors=[
+                dict(
+                    field='nonFieldErrors',
+                    messages=gettext('Cannot clear assignee because event does not have an assignee'),
+                )
+            ])
 
         event.assignee = None
         event.assigner = None
@@ -478,14 +483,14 @@ class ClearSelfAssigneFromEvent(graphene.Mutation):
         event = Event.objects.filter(id=event_id).first()
         if not event:
             return ClearSelfAssigneFromEvent(errors=[
-                dict(field='event_id', messages=gettext('Event does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Event does not exist.'))
             ])
 
         # Admin and RE can clear all other users from assignee except ME
         # FIXME: this logic does not seem right after `or`
         if event.assignee_id != info.context.user.id or info.context.user.has_perm('clear_assignee_from_event'):
             return ClearAssigneFromEvent(errors=[
-                dict(field='event_id', messages=gettext('You are not allowed to clear others from assignee.'))
+                dict(field='nonFieldErrors', messages=gettext('You are not allowed to clear others from assignee.'))
             ])
 
         event.assignee = None
@@ -521,11 +526,11 @@ class SignOffEvent(graphene.Mutation):
         event = Event.objects.filter(id=event_id).first()
         if not event:
             return SignOffEvent(errors=[
-                dict(field='event_id', messages=gettext('Event does not exist.'))
+                dict(field='nonFieldErrors', messages=gettext('Event does not exist.'))
             ])
         if not event.review_status == Event.EVENT_REVIEW_STATUS.APPROVED:
             return SignOffEvent(errors=[
-                dict(field='event_id', messages=gettext('Event is not approved yet.'))
+                dict(field='nonFieldErrors', messages=gettext('Event is not approved yet.'))
             ])
 
         event.review_status = Event.EVENT_REVIEW_STATUS.SIGNED_OFF

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -213,7 +213,6 @@ class EventSerializer(MetaInformationSerializerMixin,
             instance.refresh_from_db()
         return instance
 
-
 class EventUpdateSerializer(UpdateSerializerMixin, EventSerializer):
     id = IntegerIDField(required=True)
 

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -209,7 +209,7 @@ class EventSerializer(MetaInformationSerializerMixin,
                 event=instance,
             )
 
-            Figure.update_event_status_and_send_notifications(instance)
+            Figure.update_event_status_and_send_notifications(instance.id)
             instance.refresh_from_db()
         return instance
 

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -213,6 +213,7 @@ class EventSerializer(MetaInformationSerializerMixin,
             instance.refresh_from_db()
         return instance
 
+
 class EventUpdateSerializer(UpdateSerializerMixin, EventSerializer):
     id = IntegerIDField(required=True)
 

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -199,8 +199,8 @@ class EventSerializer(MetaInformationSerializerMixin,
 
         if is_include_triangulation_in_qa_changed:
             recipients = [user['id'] for user in Event.regional_coordinators(instance)]
-            if (instance.created_by):
-                recipients.append(instance.created_by.id)
+            if (instance.created_by_id):
+                recipients.append(instance.created_by_id)
 
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,

--- a/apps/event/tests/test_reviews.py
+++ b/apps/event/tests/test_reviews.py
@@ -176,7 +176,6 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
             self.assertIsNotNone(content['errors'])
 
     def test_self_event_assignment(self) -> None:
-
         # Admin, regional coordinator can assign self in an event
         users = [self.regional_coordinator, self.admin, self.monitoring_expert]
         for user in users:
@@ -187,19 +186,29 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
                 self.set_self_assignee_to_event_mutation,
                 variables=input,
             )
-            content = json.loads(response.content)
             self.assertResponseNoErrors(response)
+
+            content = json.loads(response.content)
             self.assertTrue(content['data']['setSelfAssigneeToEvent']['ok'], content)
             self.assertEqual(content['data']['setSelfAssigneeToEvent']['result']['assigner']['id'], str(user.id))
             self.assertEqual(content['data']['setSelfAssigneeToEvent']['result']['assignee']['id'], str(user.id))
 
     def test_user_can_clear_assignee_on_an_event(self) -> None:
-
         # Test assigner or assignee or admin can clear assignee
         users = [self.regional_coordinator, self.admin]
         event = EventFactory.create(assigner=self.regional_coordinator, assignee=self.monitoring_expert)
         for user in users:
             self.force_login(user)
+
+            # Let's assigne user
+            assign_input = {'event_id': event.id}
+            assign_response = self.query(
+                self.set_self_assignee_to_event_mutation,
+                variables=assign_input,
+            )
+            self.assertResponseNoErrors(assign_response)
+
+            # Let's un-assign user
             input = {'event_id': event.id}
             response = self.query(
                 self.clear_assignee_from_event_mutation,

--- a/apps/event/tests/test_reviews.py
+++ b/apps/event/tests/test_reviews.py
@@ -286,7 +286,12 @@ class TestEventRewviewCount(HelixGraphQLTestCase):
     def setUp(self) -> None:
         self.event = EventFactory.create()
         self.admin = create_user_with_role(USER_ROLE.ADMIN.name)
-        self.f1, self.f2, self.f3 = FigureFactory.create_batch(3, event=self.event, role=Figure.ROLE.RECOMMENDED)
+        self.f1, self.f2, self.f3 = FigureFactory.create_batch(
+            3,
+            event=self.event,
+            role=Figure.ROLE.RECOMMENDED,
+            review_status=Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED,
+        )
         self.event_query = '''
         query MyQuery {
           eventList {

--- a/apps/extraction/tests/test_filters.py
+++ b/apps/extraction/tests/test_filters.py
@@ -21,12 +21,15 @@ class TestExtractionFilter(HelixTestCase):
         cls.reg1 = CountryRegionFactory.create()
         cls.reg2 = CountryRegionFactory.create()
         cls.reg3 = CountryRegionFactory.create()
+
         cls.fig_cat1 = Figure.FIGURE_CATEGORY_TYPES.IDPS
         cls.fig_cat2 = Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT
         cls.fig_cat3 = Figure.FIGURE_CATEGORY_TYPES.IDPS
+
         cls.country1reg1 = CountryFactory.create(region=cls.reg1)
         cls.country2reg2 = CountryFactory.create(region=cls.reg2)
         cls.country3reg3 = CountryFactory.create(region=cls.reg3)
+
         cls.crisis1 = CrisisFactory.create()
         cls.crisis1.countries.set([cls.country1reg1, cls.country2reg2])
         cls.crisis2 = CrisisFactory.create()
@@ -37,11 +40,13 @@ class TestExtractionFilter(HelixTestCase):
             event_type=Crisis.CRISIS_TYPE.CONFLICT
         )
         cls.event1crisis1.countries.set([cls.country2reg2])
+
         cls.event2crisis1 = EventFactory.create(
             crisis=cls.crisis1,
             event_type=Crisis.CRISIS_TYPE.DISASTER
         )
         cls.event2crisis1.countries.set([cls.country1reg1])
+
         cls.event3crisis2 = EventFactory.create(
             crisis=cls.crisis2,
             event_type=Crisis.CRISIS_TYPE.CONFLICT
@@ -56,24 +61,26 @@ class TestExtractionFilter(HelixTestCase):
         cls.org2 = OrganizationFactory.create()
         cls.org3 = OrganizationFactory.create()
 
-        cls.entry1ev1 = EntryFactory.create(article_title="one")
-        FigureFactory.create(entry=cls.entry1ev1,
+        cls.entry1event1 = EntryFactory.create(article_title="one")
+        FigureFactory.create(entry=cls.entry1event1,
                              country=cls.country2reg2,
                              category=cls.fig_cat1,
-                             figure_cause=Crisis.CRISIS_TYPE.DISASTER,
+                             figure_cause=Crisis.CRISIS_TYPE.CONFLICT,
                              disaggregation_displacement_rural=100,
                              event=cls.event1crisis1,)
-        cls.entry2ev1 = EntryFactory.create(article_title="two")
-        FigureFactory.create(entry=cls.entry2ev1,
+
+        cls.entry2event2 = EntryFactory.create(article_title="two")
+        FigureFactory.create(entry=cls.entry2event2,
                              country=cls.country2reg2,
                              category=cls.fig_cat2,
-                             figure_cause=Crisis.CRISIS_TYPE.CONFLICT,
+                             figure_cause=Crisis.CRISIS_TYPE.DISASTER,
                              disaggregation_displacement_urban=100,
-                             event=cls.event1crisis1,)
-        cls.entry3ev2 = EntryFactory.create(article_title="three")
-        FigureFactory.create(entry=cls.entry3ev2,
+                             event=cls.event2crisis1,)
+
+        cls.entry3event2 = EntryFactory.create(article_title="three")
+        FigureFactory.create(entry=cls.entry3event2,
                              category=cls.fig_cat3,
-                             figure_cause=Crisis.CRISIS_TYPE.CONFLICT,
+                             figure_cause=Crisis.CRISIS_TYPE.DISASTER,
                              country=cls.country3reg3,
                              event=cls.event2crisis1,)
         cls.mid_sep = '2020-09-15'
@@ -87,24 +94,29 @@ class TestExtractionFilter(HelixTestCase):
             event_type=Crisis.CRISIS_TYPE.OTHER.value,
         )
         cls.fig1cat1entry1 = FigureFactory.create(
-            entry=cls.entry1ev1, category=cls.fig_cat1,
+            entry=cls.entry1event1, category=cls.fig_cat1,
             start_date=cls.mid_oct, end_date=cls.end_oct, event=cls.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.fig2cat2entry1 = FigureFactory.create(
-            entry=cls.entry1ev1, category=cls.fig_cat2,
+            entry=cls.entry1event1, category=cls.fig_cat2,
             start_date=cls.end_oct, end_date=cls.end_nov, event=cls.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.fig3cat2entry2 = FigureFactory.create(
-            entry=cls.entry2ev1, category=cls.fig_cat2,
+            entry=cls.entry2event2, category=cls.fig_cat2,
             start_date=cls.mid_sep, end_date=cls.end_oct, event=cls.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.fig4cat1entry3 = FigureFactory.create(
-            entry=cls.entry3ev2, category=cls.fig_cat3,
+            entry=cls.entry3event2, category=cls.fig_cat3,
             start_date=cls.mid_nov, end_date=None, event=cls.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.fig5cat3entry3 = FigureFactory.create(
-            entry=cls.entry3ev2, category=cls.fig_cat3,
+            entry=cls.entry3event2, category=cls.fig_cat3,
             start_date=cls.mid_nov, end_date=cls.end_nov, event=cls.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
 
         cls.fig1cat1entry1.tags.set([cls.tag1])
@@ -113,18 +125,20 @@ class TestExtractionFilter(HelixTestCase):
 
         cls.context_of_violence = ContextOfViolenceFactory.create()
         cls.figure = FigureFactory.create(
-            entry=cls.entry3ev2,
+            entry=cls.entry3event2,
             country=cls.country3reg3,
             event=cls.event2crisis1,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.event1crisis1.context_of_violence.set([cls.context_of_violence])
         cls.figure.context_of_violence.set([cls.context_of_violence])
 
         cls.context_of_violence = ContextOfViolenceFactory.create()
         cls.figure = FigureFactory.create(
-            entry=cls.entry3ev2,
+            entry=cls.entry3event2,
             country=cls.country3reg3,
             event=cls.event2crisis1,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         cls.event1crisis1.context_of_violence.set([cls.context_of_violence])
         cls.figure.context_of_violence.set([cls.context_of_violence])
@@ -132,103 +146,108 @@ class TestExtractionFilter(HelixTestCase):
     def test_filter_by_region(self):
         regions = [self.reg3.id]
         fqs = f(data=dict(filter_figure_regions=regions)).qs
-        self.assertEqual(set(fqs), {self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry3event2})
 
-    def test_filter_by_filter_figure_crisis_types(self):
-        crisis_types = [Crisis.CRISIS_TYPE.DISASTER]
+    def test_filter_by_figure_crisis_types(self):
+        crisis_types = [Crisis.CRISIS_TYPE.CONFLICT, Crisis.CRISIS_TYPE.DISASTER]
         fqs = f(data=dict(filter_figure_crisis_types=crisis_types)).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry3ev2, self.entry2ev1})
+        self.assertEqual(set(fqs), {self.entry3event2, self.entry1event1, self.entry2event2})
 
         crisis_types = [Crisis.CRISIS_TYPE.CONFLICT]
         fqs = f(data=dict(filter_figure_crisis_types=crisis_types)).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1event1})
 
-        crisis_types = ["CONFLICT", "DISASTER"]
+        crisis_types = [Crisis.CRISIS_TYPE.DISASTER]
         fqs = f(data=dict(filter_figure_crisis_types=crisis_types)).qs
-        self.assertEqual(set(fqs), {self.entry3ev2, self.entry1ev1, self.entry2ev1})
+        self.assertEqual(set(fqs), {self.entry2event2, self.entry3event2})
 
     def test_filter_by_country(self):
         data = dict(
             filter_figure_countries=[self.country3reg3.id]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry3event2})
 
     def test_filter_by_crises(self):
         data = dict(
             filter_figure_crises=[self.crisis1.id]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry2event2, self.entry3event2})
 
         data['filter_figure_crises'] = [self.crisis2.id]
         fqs = f(data=data).qs
         self.assertEqual(set(fqs), set())
 
     def test_filter_by_publishers(self):
-        self.entry1ev1.publishers.set([self.org1, self.org2])
-        self.entry2ev1.publishers.set([self.org2])
-        self.entry3ev2.publishers.set([self.org1, self.org3])
+        self.entry1event1.publishers.set([self.org1, self.org2])
+        self.entry2event2.publishers.set([self.org2])
+        self.entry3event2.publishers.set([self.org1, self.org3])
         data = dict(
             filter_entry_publishers=[self.org3.id]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry3event2})
 
         data = dict(
             filter_entry_publishers=[self.org2.id]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry2event2})
 
     def test_filter_by_displacement_types(self):
         data = dict(
             filter_figure_displacement_types=['RURAL']
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1})
-        self.assertNotIn(self.entry3ev2, fqs)
+        self.assertEqual(set(fqs), {self.entry1event1})
+        self.assertNotIn(self.entry3event2, fqs)
 
         data = dict(
             filter_figure_displacement_types=['URBAN']
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry2ev1})
-        self.assertNotIn(self.entry3ev2, fqs)
+        self.assertEqual(set(fqs), {self.entry2event2})
+        self.assertNotIn(self.entry3event2, fqs)
 
         data = dict(
             filter_figure_displacement_types=['URBAN', 'RURAL']
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1})
-        self.assertNotIn(self.entry3ev2, fqs)
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry2event2})
+        self.assertNotIn(self.entry3event2, fqs)
 
     def test_filter_by_time_frame(self):
         Figure.objects.all().delete()
         self.fig1cat1entry1 = FigureFactory.create(
-            entry=self.entry1ev1, category=self.fig_cat1,
+            entry=self.entry1event1, category=self.fig_cat1,
             start_date=self.mid_oct, end_date=self.end_oct,
             event=self.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         self.fig2cat2entry1 = FigureFactory.create(
-            entry=self.entry1ev1, category=self.fig_cat2,
+            entry=self.entry1event1, category=self.fig_cat2,
             start_date=self.end_oct, end_date=self.end_nov,
             event=self.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         self.fig3cat2entry2 = FigureFactory.create(
-            entry=self.entry2ev1, category=self.fig_cat2,
+            entry=self.entry2event2, category=self.fig_cat2,
             start_date=self.mid_sep, end_date=self.end_oct,
             event=self.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         self.fig4cat1entry3 = FigureFactory.create(
-            entry=self.entry3ev2, category=self.fig_cat1,
+            entry=self.entry3event2, category=self.fig_cat1,
             start_date=self.mid_nov, end_date=None,
             event=self.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         self.fig5cat3entry3 = FigureFactory.create(
-            entry=self.entry3ev2, category=self.fig_cat3,
+            entry=self.entry3event2, category=self.fig_cat3,
             start_date=self.mid_nov, end_date=self.end_nov,
             event=self.random_event,
+            figure_cause=Crisis.CRISIS_TYPE.OTHER,
         )
         data = dict(
             filter_figure_start_after=self.mid_oct,
@@ -236,7 +255,7 @@ class TestExtractionFilter(HelixTestCase):
         )
 
         data['filter_figure_end_before'] = self.mid_nov
-        eqs = {self.entry1ev1}
+        eqs = {self.entry1event1}
         fqs = f(data=data).qs
         self.assertEqual(set(fqs), eqs)
 
@@ -245,40 +264,40 @@ class TestExtractionFilter(HelixTestCase):
             filter_figure_tags=[self.tag1.id]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1})
+        self.assertEqual(set(fqs), {self.entry1event1})
         data = dict(
             filter_figure_tags=[self.tag3]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry2ev1})
+        self.assertEqual(set(fqs), {self.entry2event2})
 
     def test_filter_by_categories(self):
         data = dict(
             filter_figure_categories=[self.fig_cat1]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry3event2})
         data = dict(
             filter_figure_categories=[self.fig_cat2]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry2event2})
 
     def test_filter_by_category_types(self):
         data = dict(
             filter_figure_category_types=['FLOW']
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry2ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry2event2, self.entry3event2})
         data = dict(
             filter_figure_category_types=['STOCK']
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry1ev1, self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry1event1, self.entry3event2})
 
     def test_filter_by_context_of_violences(self):
         data = dict(
             filter_context_of_violences=[self.context_of_violence]
         )
         fqs = f(data=data).qs
-        self.assertEqual(set(fqs), {self.entry3ev2})
+        self.assertEqual(set(fqs), {self.entry3event2})

--- a/apps/notification/models.py
+++ b/apps/notification/models.py
@@ -127,7 +127,8 @@ class Notification(models.Model):
         recipient_set = set(recipients)
         # FIXME: do we need to just pass actor_id?
         if actor and actor.id in recipient_set:
-            # TODO: log to sentry if recipient ids has actor
+            # TODO: log to sentry if recipient ids contact actor id
+            # It indicates we have a problem with some logic
             recipient_set.remove(actor.id)
 
         recipient_list = list(recipient_set)

--- a/apps/notification/models.py
+++ b/apps/notification/models.py
@@ -125,6 +125,7 @@ class Notification(models.Model):
         text=None,
     ):
         recipient_set = set(recipients)
+        # FIXME: do we need to just pass actor_id?
         if actor and actor.id in recipient_set:
             # TODO: log to sentry if recipient ids has actor
             recipient_set.remove(actor.id)

--- a/apps/parking_lot/models.py
+++ b/apps/parking_lot/models.py
@@ -53,8 +53,5 @@ class ParkedItem(MetaInformationAbstractModel):
                                    max_length=255, blank=True, null=True)
     meta_data = JSONField(blank=True, null=True, default=None)
 
-    def move_to_entry(self):
-        ...  # TODO?
-
     def __str__(self):
-        return f'{self.country.name}- {self.title}'
+        return f'{self.country.name} - {self.title}'

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -71,7 +71,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
                 figure.save()
 
             if event:
-                Figure.update_event_status_and_send_notifications(event)
+                Figure.update_event_status_and_send_notifications(event.id)
                 event.refresh_from_db()
 
         if errors := mutation_is_not_valid(serializer):

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -63,8 +63,8 @@ class CreateUnifiedReviewComment(graphene.Mutation):
             elif (
                 figure and
                 figure.review_status == Figure.FIGURE_REVIEW_STATUS.REVIEW_RE_REQUESTED and
-                figure.event.assignee and
-                info.context.user.id == figure.event.assignee.id
+                figure.event.assignee_id and
+                info.context.user.id == figure.event.assignee_id
             ):
                 figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
                 figure.save()

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -32,7 +32,6 @@ class CreateUnifiedReviewComment(graphene.Mutation):
     @staticmethod
     @permission_checker(['review.add_reviewcomment'])
     def mutate(root, info, data):
-        from apps.event.models import Event
         from apps.entry.models import Figure
 
         serializer = UnifiedReviewCommentSerializer(

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -76,7 +76,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
 
         if instance.figure and instance.event and instance.event.assignee:
             Notification.send_safe_multiple_notifications(
-                recipients=[instance.event.assignee.id],
+                recipients=[instance.event.assignee_id],
                 event=instance.event,
                 figure=instance.figure,
                 actor=info.context.user,
@@ -85,7 +85,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
 
         if instance.figure and instance.event and instance.figure.created_by:
             Notification.send_safe_multiple_notifications(
-                recipients=[instance.figure.created_by.id],
+                recipients=[instance.figure.created_by_id],
                 event=instance.event,
                 figure=instance.figure,
                 actor=info.context.user,

--- a/schema.graphql
+++ b/schema.graphql
@@ -1497,61 +1497,6 @@ type FigureType {
   lastReviewCommentStatus: [FigureLastReviewCommentStatusType!]
 }
 
-input FigureUpdateInputType {
-  id: ID
-  wasSubfact: Boolean
-  quantifier: QUANTIFIER
-  reported: Int
-  unit: UNIT
-  householdSize: Float
-  category: FIGURE_CATEGORY_TYPES
-  term: FIGURE_TERMS
-  displacementOccurred: DISPLACEMENT_OCCURRED
-  role: ROLE
-  startDate: Date
-  startDateAccuracy: DATE_ACCURACY
-  endDate: Date
-  endDateAccuracy: DATE_ACCURACY
-  includeIdu: Boolean
-  excerptIdu: String
-  country: ID
-  isDisaggregated: Boolean
-  isHousingDestruction: Boolean
-  geoLocations: [OSMNameInputType!]
-  calculationLogic: String
-  tags: [ID!]
-  sourceExcerpt: String
-  event: ID
-  contextOfViolence: [ID!]
-  figureCause: CRISIS_TYPE
-  violence: ID
-  violenceSubType: ID
-  disasterCategory: ID
-  disasterSubCategory: ID
-  disasterType: ID
-  disasterSubType: ID
-  otherSubType: ID
-  osvSubType: ID
-  sources: [ID!]
-  uuid: String
-  disaggregationDisplacementUrban: Int
-  disaggregationDisplacementRural: Int
-  disaggregationLocationCamp: Int
-  disaggregationLocationNonCamp: Int
-  disaggregationLgbtiq: Int
-  disaggregationDisability: Int
-  disaggregationIndigenousPeople: Int
-  disaggregationSexMale: Int
-  disaggregationSexFemale: Int
-  disaggregationAge: [DisaggregatedAgeInputType!]
-  disaggregationStrataJson: [DisaggregatedStratumInputType!]
-  disaggregationConflict: Int
-  disaggregationConflictPolitical: Int
-  disaggregationConflictCriminal: Int
-  disaggregationConflictCommunal: Int
-  disaggregationConflictOther: Int
-}
-
 enum GENDER_TYPE {
   MALE
   FEMALE
@@ -1701,11 +1646,10 @@ type Mutation {
   deleteFigureTag(id: ID!): DeleteFigureTag
   exportEntries(filterFigureEvents: [ID!], filterFigureCrises: [ID!], filterFigureGlideNumber: [String!], filterFigureSources: [ID!], filterEntryPublishers: [ID!], filterEntryArticleTitle: String, filterCreatedBy: [ID!], filterFigureRegions: [ID!], filterFigureGeographicalGroups: [ID!], filterFigureCountries: [ID!], filterFigureCategoryTypes: [String!], filterFigureCategories: [String!], filterFigureStartAfter: Date, filterFigureEndBefore: Date, filterFigureRoles: [String!], filterFigureTags: [ID!], filterFigureDisplacementTypes: [String!], filterFigureTerms: [ID!], filterFigureCrisisTypes: [String!], filterFigureDisasterCategories: [ID!], filterFigureDisasterSubCategories: [ID!], filterFigureDisasterSubTypes: [ID!], filterFigureDisasterTypes: [ID!], filterFigureViolenceSubTypes: [ID!], filterFigureViolenceTypes: [ID!], filterFigureOsvSubTypes: [ID!], filterFigureHasDisaggregatedData: Boolean, filterFigureReviewStatus: [String!], filterFigureApprovedBy: [ID!], report: String, filterContextOfViolences: [ID!]): ExportEntries
   exportFigures(entry: ID, filterFigureRegions: [ID!], filterFigureGeographicalGroups: [ID!], filterFigureCountries: [ID!], filterFigureEvents: [ID!], filterFigureCrises: [ID!], filterFigureSources: [ID!], filterEntryPublishers: [ID!], filterFigureCategoryTypes: [String!], filterFigureCategories: [String!], filterFigureStartAfter: Date, filterFigureEndBefore: Date, filterFigureRoles: [String!], filterEntryArticleTitle: String, filterFigureTags: [ID!], filterFigureCrisisTypes: [String!], filterFigureGlideNumber: [String!], filterCreatedBy: [ID!], filterFigureDisplacementTypes: [String!], filterFigureTerms: [ID!], event: String, filterFigureDisasterCategories: [ID!], filterFigureDisasterSubCategories: [ID!], filterFigureDisasterSubTypes: [ID!], filterFigureDisasterTypes: [ID!], filterFigureViolenceSubTypes: [ID!], filterFigureViolenceTypes: [ID!], filterFigureOsvSubTypes: [ID!], filterFigureHasDisaggregatedData: Boolean, report: String, filterContextOfViolences: [ID!], filterFigureReviewStatus: [String!], filterFigureApprovedBy: [ID!]): ExportFigures
-  updateFigure(data: FigureUpdateInputType!): updateFigure
   deleteFigure(id: ID!): DeleteFigure
   approveFigure(id: ID!): ApproveFigure
   unapproveFigure(id: ID!): UnapproveFigure
-  reRequestReviewFigure(id: ID!): ReRequestReivewFigure
+  reRequestReviewFigure(id: ID!): ReRequestReviewFigure
   createEvent(data: EventCreateInputType!): CreateEvent
   updateEvent(data: EventUpdateInputType!): UpdateEvent
   deleteEvent(id: ID!): DeleteEvent
@@ -2384,7 +2328,7 @@ enum ROLE {
   TRIANGULATION
 }
 
-type ReRequestReivewFigure {
+type ReRequestReviewFigure {
   errors: [GenericScalar!]
   ok: Boolean
   result: FigureType
@@ -3085,10 +3029,4 @@ type ViolenceType {
   subTypes(id_Iexact: Float, ordering: String): ViolenceSubObjectListType
   extractionquerySet: [ExtractionQueryObjectType!]!
   reportSet: [ReportType!]!
-}
-
-type updateFigure {
-  errors: [GenericScalar!]
-  ok: Boolean
-  result: EntryType
 }

--- a/utils/factories.py
+++ b/utils/factories.py
@@ -215,8 +215,7 @@ class FigureFactory(DjangoModelFactory):
     quantifier = factory.Iterator(Figure.QUANTIFIER)
     reported = factory.Sequence(lambda n: n + 2)
     unit = factory.Iterator(Figure.UNIT)
-    # FIXME: household_size should not be a unit value
-    household_size = 1  # validation based on unit in the serializer
+    household_size = 2  # validation based on unit in the serializer
     role = factory.Iterator(Figure.ROLE)
     start_date = factory.LazyFunction(today().date)
     include_idu = False

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -104,18 +104,20 @@ def create_user_with_role(role: str, monitoring_sub_region: int = None, country:
             role=USER_ROLE[role],
         )
     if role == USER_ROLE.REGIONAL_COORDINATOR.name:
+        new_mr = monitoring_sub_region or MonitoringSubRegionFactory.create().id
         Portfolio.objects.create(
             user=user,
             role=USER_ROLE[role],
-            monitoring_sub_region_id=monitoring_sub_region or MonitoringSubRegionFactory.create().id
+            monitoring_sub_region_id=new_mr
         )  # assigns a new role
     elif role == USER_ROLE.MONITORING_EXPERT.name:
-        new_mr = MonitoringSubRegionFactory.create()
+        new_mr = monitoring_sub_region or MonitoringSubRegionFactory.create().id
+        new_country = country or CountryFactory.create(monitoring_sub_region_id=new_mr).id
         Portfolio.objects.create(
             user=user,
             role=USER_ROLE[role],
-            monitoring_sub_region_id=monitoring_sub_region or new_mr.id,
-            country_id=country or CountryFactory.create(monitoring_sub_region=new_mr).id
+            monitoring_sub_region_id=new_mr,
+            country_id=new_country,
         )  # assigns a new role
     return user
 


### PR DESCRIPTION
Event Status Re-calculation
===========================
- Move `update_figure_status` to Figure model
- Rename `update_event_status` to `update_event_status_and_send_notifications`
- Send notification only when review status changes on an Event
- Preserve "Sign Off" review state on event status updates

Notification
============
- Use `Notification.send_safe_multiple_notifications` instead of `Notification.send_notification` and `Notification.send_multiple_notifications`
- Do not send notification if actor is the recipient
- Do not send same kind of notification to same person more than once

Figure Mutations
================
- Group figure related mutations
- Recalculate event status on figure delete mutation
- Remove mutation for figure update
- Add validations to figure mutations: - Send errors to 'nonFieldErrors' key instead of 'id' - Do not let approved figures to be approved. - Only let approved figures to be un-approved. - Only in-progress figures can be re-requested review.

Entry Mutations
===============
- Update how notifications are sent and event status are recalculated for entry save operation
- Fixed a bug where deleting all figures would not send notification or re-calculate the event status

Validations
- Use nonFieldErrors instead of event_id and user_id for general errors
- Get regional_coordinators of a user instead of a figure
- Do not let users clear assignee on event that is not assigned
- Only change review_status for figure on review_comment if the
- review_status is either re_requested or not_started
- Calculate event status after figure review update
- Setup household_size on figure factory to be 2

Tests
=====
- Fix failing test because of added validations on figure mutations
- Fix infamously failing test `test_filter_by_figure_crisis_types`

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
