### PR TITLE
Feature/validations more validations

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -966,11 +966,11 @@ class Figure(MetaInformationArchiveAbstractModel,
 
     # TODO: move this to event model
     @classmethod
-    def update_event_status_and_send_notifications(cls, event_from_args):
+    def update_event_status_and_send_notifications(cls, event_id):
         from apps.event.models import Event
 
         event = Event.objects.filter(
-            id=event_from_args.id
+            id=event_id
         ).annotate(
             **Event.annotate_review_figures_count()
         ).first()

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -312,7 +312,7 @@ class DeleteFigure(graphene.Mutation):
         if _type:
             recipients = [user['id'] for user in Event.regional_coordinators(
                 instance.event,
-                figure=instance,
+                actor=info.context.user,
             )]
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,
@@ -322,7 +322,7 @@ class DeleteFigure(graphene.Mutation):
                 event=instance.event,
             )
 
-        Figure.update_event_status_and_send_notifications(instance.event)
+        Figure.update_event_status_and_send_notifications(instance.event.id)
         instance.event.refresh_from_db()
 
         return DeleteFigure(errors=None, ok=True)
@@ -356,7 +356,7 @@ class ApproveFigure(graphene.Mutation):
 
         # NOTE: not sending notification when figure is approved as it is not actionable
 
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return ApproveFigure(result=figure, errors=None, ok=True)
@@ -405,7 +405,7 @@ class UnapproveFigure(graphene.Mutation):
         if _type:
             recipients = [user['id'] for user in Event.regional_coordinators(
                 figure.event,
-                figure=figure,
+                actor=info.context.user,
             )]
             Notification.send_safe_multiple_notifications(
                 recipients=recipients,
@@ -416,7 +416,7 @@ class UnapproveFigure(graphene.Mutation):
             )
 
         # Update event status
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return UnapproveFigure(result=figure, errors=None, ok=True)
@@ -459,7 +459,7 @@ class ReRequestReviewFigure(graphene.Mutation):
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,
             )
 
-        Figure.update_event_status_and_send_notifications(figure.event)
+        Figure.update_event_status_and_send_notifications(figure.event.id)
         figure.event.refresh_from_db()
 
         return ReRequestReviewFigure(result=figure, errors=None, ok=True)

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -719,7 +719,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     affected_events.append(figure.event)
 
                 for figure in deleted_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -727,7 +730,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         event=figure.event,
                     )
                 for figure in deleted_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -735,7 +741,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         event=figure.event,
                     )
                 for figure in updated_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -746,7 +755,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     Figure.update_figure_status(figure)
                     figure.refresh_from_db()
                 for figure in updated_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -760,7 +772,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                     Figure.update_figure_status(figure)
                     figure.refresh_from_db()
                 for figure in created_figures_for_signed_off_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -769,7 +784,10 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         figure=figure,
                     )
                 for figure in created_figures_for_approved_events:
-                    recipients = [user['id'] for user in Event.regional_coordinators(figure.event, figure=figure)]
+                    recipients = [user['id'] for user in Event.regional_coordinators(
+                        figure.event,
+                        actor=self.context['request'].user,
+                    )]
                     Notification.send_safe_multiple_notifications(
                         recipients=recipients,
                         actor=self.context['request'].user,
@@ -780,7 +798,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
 
                 # FIXME: check if unique works
                 for event in list(set(affected_events)):
-                    Figure.update_event_status_and_send_notifications(event)
+                    Figure.update_event_status_and_send_notifications(event.id)
                     event.refresh_from_db()
 
         entry = super().update(instance, validated_data)

--- a/apps/event/models.py
+++ b/apps/event/models.py
@@ -333,14 +333,16 @@ class Event(MetaInformationArchiveAbstractModel, models.Model):
 
     # FIXME: this is wrong, this should see event and user not event and figure
     @staticmethod
-    def regional_coordinators(event, figure=None):
-        figure_regional_coordinators = User.objects.none()
+    def regional_coordinators(event, actor=None):
+        actor_regional_coordinators = User.objects.none()
         event_regional_coordinators = User.objects.none()
 
-        if figure and figure.country:
-            figure_regional_coordinators = User.objects.filter(
+        if actor:
+            actor_regional_coordinators = User.objects.filter(
                 portfolios__role=USER_ROLE.REGIONAL_COORDINATOR,
-                portfolios__country=figure.country
+                portfolios__country__in=actor.portfolios.values(
+                    'country'
+                )
             )
 
         if event.countries:
@@ -350,7 +352,7 @@ class Event(MetaInformationArchiveAbstractModel, models.Model):
                     'portfolio__monitoring_sub_region'
                 )
             )
-        coordinators = figure_regional_coordinators | event_regional_coordinators
+        coordinators = actor_regional_coordinators | event_regional_coordinators
         return coordinators.values('id')
 
     @classmethod

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -198,7 +198,10 @@ class EventSerializer(MetaInformationSerializerMixin,
         instance = super().update(instance, validated_data)
 
         if is_include_triangulation_in_qa_changed:
-            recipients = [user['id'] for user in Event.regional_coordinators(instance)]
+            recipients = [user['id'] for user in Event.regional_coordinators(
+                instance,
+                actor=self.context['request'].user,
+            )]
             if (instance.created_by):
                 recipients.append(instance.created_by.id)
 
@@ -209,7 +212,7 @@ class EventSerializer(MetaInformationSerializerMixin,
                 event=instance,
             )
 
-            Figure.update_event_status_and_send_notifications(instance)
+            Figure.update_event_status_and_send_notifications(instance.id)
             instance.refresh_from_db()
         return instance
 

--- a/apps/event/tests/test_reviews.py
+++ b/apps/event/tests/test_reviews.py
@@ -176,7 +176,6 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
             self.assertIsNotNone(content['errors'])
 
     def test_self_event_assignment(self) -> None:
-
         # Admin, regional coordinator can assign self in an event
         users = [self.regional_coordinator, self.admin, self.monitoring_expert]
         for user in users:
@@ -187,19 +186,29 @@ class TestEventReviewGraphQLTestCase(HelixGraphQLTestCase):
                 self.set_self_assignee_to_event_mutation,
                 variables=input,
             )
-            content = json.loads(response.content)
             self.assertResponseNoErrors(response)
+
+            content = json.loads(response.content)
             self.assertTrue(content['data']['setSelfAssigneeToEvent']['ok'], content)
             self.assertEqual(content['data']['setSelfAssigneeToEvent']['result']['assigner']['id'], str(user.id))
             self.assertEqual(content['data']['setSelfAssigneeToEvent']['result']['assignee']['id'], str(user.id))
 
     def test_user_can_clear_assignee_on_an_event(self) -> None:
-
         # Test assigner or assignee or admin can clear assignee
         users = [self.regional_coordinator, self.admin]
         event = EventFactory.create(assigner=self.regional_coordinator, assignee=self.monitoring_expert)
         for user in users:
             self.force_login(user)
+
+            # Let's assigne user
+            assign_input = {'event_id': event.id}
+            assign_response = self.query(
+                self.set_self_assignee_to_event_mutation,
+                variables=assign_input,
+            )
+            self.assertResponseNoErrors(assign_response)
+
+            # Let's un-assign user
             input = {'event_id': event.id}
             response = self.query(
                 self.clear_assignee_from_event_mutation,

--- a/apps/notification/models.py
+++ b/apps/notification/models.py
@@ -126,7 +126,8 @@ class Notification(models.Model):
     ):
         recipient_set = set(recipients)
         if actor and actor.id in recipient_set:
-            # TODO: log to sentry if recipient ids has actor
+            # TODO: log to sentry if recipient ids contact actor id
+            # It indicates we have a problem with some logic
             recipient_set.remove(actor.id)
 
         recipient_list = list(recipient_set)

--- a/apps/parking_lot/models.py
+++ b/apps/parking_lot/models.py
@@ -53,8 +53,5 @@ class ParkedItem(MetaInformationAbstractModel):
                                    max_length=255, blank=True, null=True)
     meta_data = JSONField(blank=True, null=True, default=None)
 
-    def move_to_entry(self):
-        ...  # TODO?
-
     def __str__(self):
-        return f'{self.country.name}- {self.title}'
+        return f'{self.country.name} - {self.title}'

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -71,7 +71,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
                 figure.save()
 
             if event:
-                Figure.update_event_status_and_send_notifications(event)
+                Figure.update_event_status_and_send_notifications(event.id)
                 event.refresh_from_db()
 
         if errors := mutation_is_not_valid(serializer):

--- a/utils/factories.py
+++ b/utils/factories.py
@@ -215,8 +215,7 @@ class FigureFactory(DjangoModelFactory):
     quantifier = factory.Iterator(Figure.QUANTIFIER)
     reported = factory.Sequence(lambda n: n + 2)
     unit = factory.Iterator(Figure.UNIT)
-    # FIXME: household_size should not be a unit value
-    household_size = 1  # validation based on unit in the serializer
+    household_size = 2  # validation based on unit in the serializer
     role = factory.Iterator(Figure.ROLE)
     start_date = factory.LazyFunction(today().date)
     include_idu = False

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -104,18 +104,20 @@ def create_user_with_role(role: str, monitoring_sub_region: int = None, country:
             role=USER_ROLE[role],
         )
     if role == USER_ROLE.REGIONAL_COORDINATOR.name:
+        new_mr = monitoring_sub_region or MonitoringSubRegionFactory.create().id
         Portfolio.objects.create(
             user=user,
             role=USER_ROLE[role],
-            monitoring_sub_region_id=monitoring_sub_region or MonitoringSubRegionFactory.create().id
+            monitoring_sub_region_id=new_mr
         )  # assigns a new role
     elif role == USER_ROLE.MONITORING_EXPERT.name:
-        new_mr = MonitoringSubRegionFactory.create()
+        new_mr = monitoring_sub_region or MonitoringSubRegionFactory.create().id
+        new_country = country or CountryFactory.create(monitoring_sub_region_id=new_mr).id
         Portfolio.objects.create(
             user=user,
             role=USER_ROLE[role],
-            monitoring_sub_region_id=monitoring_sub_region or new_mr.id,
-            country_id=country or CountryFactory.create(monitoring_sub_region=new_mr).id
+            monitoring_sub_region_id=new_mr,
+            country_id=new_country,
         )  # assigns a new role
     return user
 


### PR DESCRIPTION
- Use nonFieldErrors instead of event_id and user_id for general errors
- Get regional_coordinators of a user instead of a figure
- Do not let users clear assignee on event that is not assigned
- Only change review_status for figure on review_comment if the
  review_status is either re_requested or not_started
- Calculate event status after figure review update
- Setup household_size on figure factory to be 2


Depends on https://github.com/idmc-labs/helix-server/pull/405

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
