### PR TITLE
Send notificaiton and update event status when entry was removed

### DIFF
--- a/apps/event/mutations.py
+++ b/apps/event/mutations.py
@@ -544,7 +544,8 @@ class SignOffEvent(graphene.Mutation):
 
         recipients = [
             user['id'] for user in Event.regional_coordinators(
-                event, actor=info.context.user
+                event,
+                actor=info.context.user,
             )
         ]
         if event.created_by_id:

--- a/apps/event/mutations.py
+++ b/apps/event/mutations.py
@@ -542,7 +542,11 @@ class SignOffEvent(graphene.Mutation):
         event.review_status = Event.EVENT_REVIEW_STATUS.SIGNED_OFF
         event.save()
 
-        recipients = [user['id'] for user in Event.regional_coordinators(event)]
+        recipients = [
+            user['id'] for user in Event.regional_coordinators(
+                event, actor=info.context.user
+            )
+        ]
         if event.created_by_id:
             recipients.append(event.created_by_id)
 

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -198,7 +198,10 @@ class EventSerializer(MetaInformationSerializerMixin,
         instance = super().update(instance, validated_data)
 
         if is_include_triangulation_in_qa_changed:
-            recipients = [user['id'] for user in Event.regional_coordinators(instance)]
+            recipients = [user['id'] for user in Event.regional_coordinators(
+                instance,
+                actor=self.context['request'].user,
+            )]
             if (instance.created_by_id):
                 recipients.append(instance.created_by_id)
 


### PR DESCRIPTION
Addresses 
https://github.com/idmc-labs/helix-server/issues/398
https://github.com/idmc-labs/helix-server/issues/399

## Changes

* send notification and update event status when the entry was removed

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
