### PR TITLE
Fix/pass entry notifications

### DIFF
--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -451,6 +451,7 @@ class UnapproveFigure(graphene.Mutation):
                 type=_type,
                 actor=info.context.user,
                 event=figure.event,
+                entry=figure.entry,
                 figure=figure,
             )
 
@@ -493,6 +494,7 @@ class ReRequestReviewFigure(graphene.Mutation):
             Notification.send_safe_multiple_notifications(
                 event=figure.event,
                 figure=figure,
+                entry=figure.entry,
                 recipients=[figure.event.assignee_id],
                 actor=info.context.user,
                 type=Notification.Type.FIGURE_RE_REQUESTED_REVIEW,

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -715,6 +715,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_DELETED_IN_SIGNED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                     )
                 for figure in deleted_figures_for_approved_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
@@ -726,6 +727,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_DELETED_IN_APPROVED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                     )
                 for figure in updated_figures_for_signed_off_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
@@ -737,6 +739,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_UPDATED_IN_SIGNED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                         figure=figure,
                     )
                     Figure.update_figure_status(figure)
@@ -750,6 +753,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_UPDATED_IN_APPROVED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                         figure=figure,
                     )
                     Figure.update_figure_status(figure)
@@ -765,6 +769,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_CREATED_IN_SIGNED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                         figure=figure,
                     )
                 for figure in created_figures_for_approved_events:
@@ -777,6 +782,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         actor=self.context['request'].user,
                         type=Notification.Type.FIGURE_CREATED_IN_APPROVED_EVENT,
                         event=figure.event,
+                        entry=figure.entry,
                         figure=figure,
                     )
                 for event_id in affected_event_ids:

--- a/apps/review/mutations.py
+++ b/apps/review/mutations.py
@@ -81,6 +81,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
             Notification.send_safe_multiple_notifications(
                 recipients=[instance.event.assignee_id],
                 event=instance.event,
+                entry=instance.figure.entry,
                 figure=instance.figure,
                 actor=info.context.user,
                 type=Notification.Type.REVIEW_COMMENT_CREATED,
@@ -90,6 +91,7 @@ class CreateUnifiedReviewComment(graphene.Mutation):
             Notification.send_safe_multiple_notifications(
                 recipients=[instance.figure.created_by_id],
                 event=instance.event,
+                entry=instance.figure.entry,
                 figure=instance.figure,
                 actor=info.context.user,
                 type=Notification.Type.REVIEW_COMMENT_CREATED,


### PR DESCRIPTION

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations