### PR TITLE
Update figure status if assignee updates figure

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -956,12 +956,13 @@ class Figure(MetaInformationArchiveAbstractModel,
         return entry.can_be_updated_by(user)
 
     @classmethod
-    def update_figure_status(cls, figure):
+    def update_figure_status(cls, figure, current_logged_in_user):
         # Change figure status
-        figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
-        if figure.figure_review_comments.count() > 0:
-            figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
-        figure.save()
+        if figure.event and figure.event.assignee == current_logged_in_user:
+            figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
+            if figure.figure_review_comments.count() > 0:
+                figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+            figure.save()
 
     # TODO: move this to event model
     @classmethod

--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -956,12 +956,22 @@ class Figure(MetaInformationArchiveAbstractModel,
         return entry.can_be_updated_by(user)
 
     @classmethod
-    def update_figure_status(cls, figure, current_logged_in_user):
-        # Change figure status
-        if figure.event and figure.event.assignee == current_logged_in_user:
+    def update_figure_status(cls, figure):
+        review_comments_count = figure.figure_review_comments.count()
+
+        if (
+            review_comments_count > 0 and
+            (figure.review_status == Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED or
+                figure.review_status == Figure.FIGURE_REVIEW_STATUS.APPROVED)
+        ):
+            figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
+            figure.save()
+        elif (
+            review_comments_count <= 0 and
+            (figure.review_status == Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS or
+                figure.review_status == Figure.FIGURE_REVIEW_STATUS.APPROVED)
+        ):
             figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_NOT_STARTED
-            if figure.figure_review_comments.count() > 0:
-                figure.review_status = Figure.FIGURE_REVIEW_STATUS.REVIEW_IN_PROGRESS
             figure.save()
 
     # TODO: move this to event model

--- a/apps/entry/mutations.py
+++ b/apps/entry/mutations.py
@@ -398,7 +398,7 @@ class ApproveFigure(graphene.Mutation):
                 dict(field='nonFieldErrors', messages=gettext('Approved figures cannot be approved'))
             ])
 
-        figure.review_status = Figure.FIGURE_REVIEW_STATUS.APPROVED.value
+        figure.review_status = Figure.FIGURE_REVIEW_STATUS.APPROVED
         figure.approved_by = info.context.user
         figure.approved_on = timezone.now()
         figure.save()

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -754,7 +754,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         entry=figure.entry,
                         figure=figure,
                     )
-                    Figure.update_figure_status(figure)
+                    Figure.update_figure_status(figure, self.context['request'].user)
                 for figure in updated_figures_for_approved_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
                         figure.event,
@@ -772,9 +772,9 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         entry=figure.entry,
                         figure=figure,
                     )
-                    Figure.update_figure_status(figure)
+                    Figure.update_figure_status(figure, self.context['request'].user)
                 for figure in updated_figures_for_other_events:
-                    Figure.update_figure_status(figure)
+                    Figure.update_figure_status(figure, self.context['request'].user)
                 for figure in created_figures_for_signed_off_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
                         figure.event,

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -754,7 +754,7 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         entry=figure.entry,
                         figure=figure,
                     )
-                    Figure.update_figure_status(figure, self.context['request'].user)
+                    Figure.update_figure_status(figure)
                 for figure in updated_figures_for_approved_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
                         figure.event,
@@ -772,9 +772,9 @@ class EntryCreateSerializer(MetaInformationSerializerMixin,
                         entry=figure.entry,
                         figure=figure,
                     )
-                    Figure.update_figure_status(figure, self.context['request'].user)
+                    Figure.update_figure_status(figure)
                 for figure in updated_figures_for_other_events:
-                    Figure.update_figure_status(figure, self.context['request'].user)
+                    Figure.update_figure_status(figure)
                 for figure in created_figures_for_signed_off_events:
                     recipients = [user['id'] for user in Event.regional_coordinators(
                         figure.event,


### PR DESCRIPTION
Addresses
https://github.com/idmc-labs/helix-server/issues/421


## Changes

* Change figure status if assignee updates figure
* Figure status should not be changed if other than assignee changed figure

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
