### PR TITLE
Add fake test to show migrations

### DIFF
--- a/apps/country/migrations/0015_update_and_delete_geolocation_group.py
+++ b/apps/country/migrations/0015_update_and_delete_geolocation_group.py
@@ -42,6 +42,8 @@ class Migration(migrations.Migration):
             location_to_delete.delete()
 
     dependencies = [
+        ('extraction', '0035_extractionquery_filter_is_figure_to_be_reviewed'),
+        ('report', '0045_report_filter_is_figure_to_be_reviewed'),
         ('country', '0014_merge_20210702_0747'),
     ]
 

--- a/helix/tests.py
+++ b/helix/tests.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+
+class FakeTest(TestCase):
+    """
+    This test is for running migrations only
+    docker-compose run --rm server ./manage.py test -v 2 --pattern="helix/tests.py"
+    """
+    def test_fake(self):
+        pass

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,11 @@ if [ "$CI" == "true" ]; then
 
     set -e
 
-    COVERAGE_PROCESS_START=`pwd`/.coveragerc coverage run -m py.test --durations=10
+    # To show migration logs
+    ./manage.py test --keepdb -v 2 helix.tests
+
+    # Now run all tests
+    COVERAGE_PROCESS_START=`pwd`/.coveragerc coverage run -m py.test --reuse-db --durations=10
 
     # Collect/Generate reports
     coverage report -i


### PR DESCRIPTION
## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
