### PR TITLE
Fix enum class not found in migration

### DIFF
--- a/apps/entry/migrations/0078_generate_source_preview_and_clear_url.py
+++ b/apps/entry/migrations/0078_generate_source_preview_and_clear_url.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         )
         for entry in entries_with_urls_but_no_source_previews:
             source_preview = SourcePreview.objects.create(
-                url=entry.url, status=SourcePreview.PREVIEW_STATUS.FAILED
+                url=entry.url, status=2 # SourcePreview.PREVIEW_STATUS.FAILED
             )
             entry.preview = source_preview
             entry.save()


### PR DESCRIPTION
## Changes

* Fix enum class not found in migration

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
