### PR TITLE
Fix/remove stock and flow filter logic

### DIFF
--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -569,6 +569,36 @@ class Figure(MetaInformationArchiveAbstractModel,
 
     # methods
     @classmethod
+    def filtered_nd_figures(
+        cls,
+        qs: QuerySet,
+        start_date: Optional[date],
+        end_date: Optional[date] = None,
+    ):
+        year_difference = ExpressionWrapper(
+            ExtractYear('end_date') - ExtractYear('start_date'),
+            output_field=fields.IntegerField(),
+        )
+        qs = qs.annotate(year_difference=year_difference)
+
+        same_year_figures = qs.filter(
+            category=Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.value,
+            year_difference__lt=1,
+        )
+        mutiple_year_figures = qs.filter(
+            category=Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.value,
+            year_difference__gte=1,
+        )
+        if start_date:
+            same_year_figures = same_year_figures.filter(start_date__gte=start_date)
+            mutiple_year_figures = mutiple_year_figures.filter(end_date__gte=start_date)
+        if end_date:
+            same_year_figures = same_year_figures.filter(start_date__lte=end_date)
+            mutiple_year_figures = mutiple_year_figures.filter(end_date__lte=end_date)
+
+        return same_year_figures | mutiple_year_figures
+
+    @classmethod
     def annotate_stock_and_flow_dates(cls):
         return {
             'flow_start_date': Case(
@@ -688,36 +718,6 @@ class Figure(MetaInformationArchiveAbstractModel,
             Figure.FIGURE_TERMS.PARTIALLY_DESTROYED_HOUSING.value,
             Figure.FIGURE_TERMS.UNINHABITABLE_HOUSING.value,
         ]
-
-    @classmethod
-    def filtered_nd_figures(
-        cls,
-        qs: QuerySet,
-        start_date: Optional[date],
-        end_date: Optional[date] = None,
-    ):
-        year_difference = ExpressionWrapper(
-            ExtractYear('end_date') - ExtractYear('start_date'),
-            output_field=fields.IntegerField(),
-        )
-        qs = qs.annotate(year_difference=year_difference)
-
-        same_year_figures = qs.filter(
-            category=Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.value,
-            year_difference__lt=1,
-        )
-        mutiple_year_figures = qs.filter(
-            category=Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.value,
-            year_difference__gte=1,
-        )
-        if start_date:
-            same_year_figures = same_year_figures.filter(start_date__gte=start_date)
-            mutiple_year_figures = mutiple_year_figures.filter(end_date__gte=start_date)
-        if end_date:
-            same_year_figures = same_year_figures.filter(start_date__lte=end_date)
-            mutiple_year_figures = mutiple_year_figures.filter(end_date__lte=end_date)
-
-        return same_year_figures | mutiple_year_figures
 
     @classmethod
     def filtered_idp_figures(

--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -744,6 +744,22 @@ class Figure(MetaInformationArchiveAbstractModel,
         return qs
 
     @classmethod
+    def filtered_idp_figures_for_listing(
+        cls,
+        qs: QuerySet,
+        start_date,
+        end_date
+    ):
+        # NOTE: For the date range filter in table start_date and end_date is required arguments.
+        if start_date and end_date:
+            qs = qs.filter(
+                Q(end_date__lte=end_date, start_date__gte=start_date) |
+                Q(end_date__gte=start_date, start_date__lte=end_date) |
+                Q(start_date__gte=start_date, start_date__lte=end_date, end_date__isnull=True)
+            ).distinct()
+        return qs
+
+    @classmethod
     def get_excel_sheets_data(cls, user_id, filters):
         from apps.extraction.filters import FigureExtractionFilterSet
 

--- a/apps/entry/models.py
+++ b/apps/entry/models.py
@@ -884,7 +884,7 @@ class Figure(MetaInformationArchiveAbstractModel,
                 filter=~Q(entry__publishers__name=''),
                 distinct=True
             ),
-            year=ExtractYear("start_date"),
+            year=ExtractYear("end_date"),
             context_of_violences=StringAgg('context_of_violence__name', '; ', distinct=True),
             tags_name=StringAgg('tags__name', '; ', distinct=True),
             sources_name=StringAgg('sources__name', '; ', distinct=True),

--- a/apps/extraction/filters.py
+++ b/apps/extraction/filters.py
@@ -622,8 +622,8 @@ class FigureExtractionFilterSet(BaseFigureExtractionFilterSet):
         flow_qs = Figure.filtered_nd_figures(
             queryset, start_date, end_date
         )
-        stock_qs = Figure.filtered_idp_figures(
-            queryset, reference_point=end_date
+        stock_qs = Figure.filtered_idp_figures_for_listing(
+            queryset, start_date, end_date
         )
         return flow_qs | stock_qs
 
@@ -650,8 +650,8 @@ class ReportFigureExtractionFilterSet(BaseFigureExtractionFilterSet):
         flow_qs = Figure.filtered_nd_figures(
             queryset, start_date, end_date
         )
-        stock_qs = Figure.filtered_idp_figures(
-            queryset, reference_point=end_date
+        stock_qs = Figure.filtered_idp_figures_for_listing(
+            queryset, start_date, end_date
         )
         return flow_qs | stock_qs
 

--- a/apps/extraction/models.py
+++ b/apps/extraction/models.py
@@ -206,11 +206,11 @@ class QueryAbstractModel(models.Model):
         from apps.extraction.filters import FigureExtractionFilterSet
         return FigureExtractionFilterSet(data=self.get_filter_kwargs).qs
 
+    # FIXME: we may not need this anymore
     @property
     def extract_report_figures(self) -> ['Figure']:  # noqa
         """
-        Use this method in report only, end date is passed as reference point
-        in this method
+        Use this method in report only
         """
         from apps.extraction.filters import ReportFigureExtractionFilterSet
         return ReportFigureExtractionFilterSet(data=self.get_filter_kwargs).qs

--- a/apps/report/models.py
+++ b/apps/report/models.py
@@ -252,21 +252,7 @@ class Report(MetaInformationArchiveAbstractModel,
         }
 
     @property
-    def is_legacy(self):
-        # TODO: use generated_from after next migration
-        return self.generated_from or not self.generated
-
-    # FIXME: we need to use dataloader
-    @property
-    def attached_figures(self):
-        figures_ids = (Report.objects.filter(id=self.id) |
-                       Report.objects.get(id=self.id).masterfact_reports.all()).values('figures')
-        return Figure.objects.filter(id__in=figures_ids)
-
-    @property
     def report_figures(self):
-        if self.is_legacy:
-            return self.attached_figures
         return self.extract_report_figures
 
     @property

--- a/apps/report/tests/test_apis.py
+++ b/apps/report/tests/test_apis.py
@@ -411,19 +411,18 @@ class TestReportFilter(HelixGraphQLTestCase):
     def test_report_should_list_entries_between_figure_start_date_and_figure_end_date(self):
         # Create entries such that report end date is between figure start
         # date and figure end date
-        for i in range(3):
+        for _ in range(3):
             entry = EntryFactory.create()
             FigureFactory.create(
                 entry=entry,
                 start_date=timezone.now() + timezone.timedelta(days=-15),
-                end_date=timezone.now() + timezone.timedelta(days=20),
+                end_date=timezone.now() + timezone.timedelta(days=-10),
                 category=self.category,
                 event=self.event
             )
-
-        # Creat reports where  reference point is not in renge
+        # Create reports where  reference point is not in range
         # Should exclude these figures
-        for i in range(2):
+        for _ in range(2):
             entry = EntryFactory.create()
             FigureFactory.create(
                 entry=entry,
@@ -463,7 +462,7 @@ class TestReportFilter(HelixGraphQLTestCase):
         self.assertEqual(figures_count, 3)
 
     def test_report_should_include_figures_without_end_date_in_range(self):
-        for i in range(3):
+        for _ in range(3):
             entry = EntryFactory.create()
             FigureFactory.create(
                 entry=entry,
@@ -472,9 +471,9 @@ class TestReportFilter(HelixGraphQLTestCase):
                 event=self.event,
             )
 
-        # Creat reports where reference point is not in renge
+        # Create reports where reference point is not in range
         # Should exclude these figures
-        for i in range(2):
+        for _ in range(2):
             entry = EntryFactory.create()
             FigureFactory.create(
                 entry=entry,

--- a/apps/report/tests/test_apis.py
+++ b/apps/report/tests/test_apis.py
@@ -461,69 +461,6 @@ class TestReportFilter(HelixGraphQLTestCase):
         figures_count = figures["data"]["report"]["figuresReport"]["totalCount"]
         self.assertEqual(figures_count, 3)
 
-    def test_report_should_include_figures_without_end_date_in_range(self):
-        for _ in range(3):
-            entry = EntryFactory.create()
-            FigureFactory.create(
-                entry=entry,
-                start_date=timezone.now() + timezone.timedelta(days=-15),
-                category=self.category,
-                event=self.event,
-            )
-
-        # Create reports where reference point is not in range
-        # Should exclude these figures
-        for _ in range(2):
-            entry = EntryFactory.create()
-            FigureFactory.create(
-                entry=entry,
-                start_date=timezone.now() + timezone.timedelta(days=50),
-                end_date=timezone.now() + timezone.timedelta(days=50),
-                category=self.category,
-                event=self.event,
-            )
-
-        response = self.query(
-            self.create_report,
-            input_data=self.input,
-        )
-        report = response.json()
-        report_id = report["data"]["createReport"]["result"]["id"]
-
-        saved_report = Report.objects.get(pk=report_id)
-        self.assertEqual(saved_report.report_figures.count(), 3)
-
-        self.assertEqual(
-            Figure.filtered_idp_figures(
-                Figure.objects.all(), self.input['filterFigureEndBefore'],
-            ).count(),
-            3,
-        )
-
-        # Test for entries
-        response = self.query(
-            self.entries_report_query,
-            variables=dict(
-                id=str(report_id),
-            )
-        )
-        entries = response.json()
-        entries_count = entries["data"]["report"]["entriesReport"]["totalCount"]
-        self.assertEqual(len(entries["data"]["report"]["entriesReport"]["results"]), 3)
-        self.assertEqual(entries_count, 3)
-
-        # Test for figures
-        response = self.query(
-            self.figures_report_query,
-            variables=dict(
-                id=str(report_id),
-            )
-        )
-        figures = response.json()
-        self.assertEqual(len(figures["data"]["report"]["figuresReport"]["results"]), 3)
-        entries_count = figures["data"]["report"]["figuresReport"]["totalCount"]
-        self.assertEqual(entries_count, 3)
-
 
 class TestPrivatePublicReports(HelixGraphQLTestCase):
     def setUp(self) -> None:

--- a/apps/report/tests/test_models.py
+++ b/apps/report/tests/test_models.py
@@ -65,7 +65,7 @@ class TestReportModel(HelixTestCase):
                          r.countries_report)
 
     def test_001_appropriate_typology_checks(self):
-        figure = FigureFactory.create(
+        FigureFactory.create(
             reported=200,
             category=Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT,
             role=Figure.ROLE.RECOMMENDED,
@@ -73,9 +73,13 @@ class TestReportModel(HelixTestCase):
             disaggregation_conflict=100,
             disaggregation_conflict_political=100,
             event=self.event_conflict,
+            start_date='2019-02-01',
+            end_date='2019-04-01',
         )
-        report = ReportFactory.create(generated=False)
-        report.figures.add(figure)
+        report = ReportFactory.create(
+            filter_figure_start_after='2019-01-01',
+            filter_figure_end_before='2019-12-31',
+        )
         gen = ReportGeneration.objects.create(report=report)
 
         assert report.report_figures.count() == 1

--- a/apps/report/utils.py
+++ b/apps/report/utils.py
@@ -662,7 +662,7 @@ def report_disaster_event(report):
     ).values('event').order_by().annotate(
         event_id=F('event_id'),
         event_name=F('event__name'),
-        event_year=Extract('event__start_date', 'year'),
+        event_year=Extract('event__end_date', 'year'),
         event_start_date=F('event__start_date'),
         event_end_date=F('event__end_date'),
         event_category=F('event__disaster_category__name'),


### PR DESCRIPTION
Addresses
https://github.com/idmc-labs/helix2.0-meta/issues/257
https://github.com/idmc-labs/helix2.0-meta/issues/262


## Changes

* Remove report filter legacy method
* Add separate filter logic for date range in figures and reprot


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
