### PR TITLE
Add pfa visibility update permission to regional coordinators

### DIFF
--- a/apps/report/tests/test_apis.py
+++ b/apps/report/tests/test_apis.py
@@ -696,7 +696,8 @@ class TestPaf(HelixGraphQLTestCase):
             self.set_pfa_visible_in_gidd,
             variables={'reportId': self.report.id, 'isPfaVisibleInGidd': True}
         )
-        self.assertIn(PERMISSION_DENIED_MESSAGE, response.json()['errors'][0]['message'])
+        is_pfa_visible_in_gidd = update_response.json()['data']['updateReport']['result']['isPfaVisibleInGidd']
+        self.assertEqual(is_pfa_visible_in_gidd, False)
 
         self.force_login(self.monitoring_expert)
         response = self.query(

--- a/apps/users/roles.py
+++ b/apps/users/roles.py
@@ -61,7 +61,7 @@ PERMISSIONS = {
         PERMISSION_ACTION.self_assign: {PERMISSION_ENTITY.event},
         PERMISSION_ACTION.clear_assignee: {PERMISSION_ENTITY.event},
         PERMISSION_ACTION.clear_self_assignee: {PERMISSION_ENTITY.event},
-        PERMISSION_ACTION.update_pfa_visibility: set(),
+        PERMISSION_ACTION.update_pfa_visibility: {PERMISSION_ENTITY.report},
     },
     USER_ROLE.MONITORING_EXPERT: {
         PERMISSION_ACTION.add: MONITORING_EXPERT_MODELS,


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/695

## Changes

* Regional Coordinators should be able to change PFA visibility in GIDD

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
