### PR TITLE
Feature/reset filter fields for gidd reports

### DIFF
--- a/apps/extraction/models.py
+++ b/apps/extraction/models.py
@@ -13,10 +13,6 @@ from apps.entry.constants import STOCK, FLOW
 
 
 class QueryAbstractModel(models.Model):
-    name = models.CharField(
-        verbose_name=_('Name'),
-        max_length=128
-    )
     filter_figure_geographical_groups = models.ManyToManyField(
         'country.GeographicalGroup',
         verbose_name=_('Geographical Group'),
@@ -231,4 +227,7 @@ class QueryAbstractModel(models.Model):
 
 
 class ExtractionQuery(MetaInformationAbstractModel, QueryAbstractModel):
-    pass
+    name = models.CharField(
+        verbose_name=_('Name'),
+        max_length=128
+    )

--- a/apps/report/models.py
+++ b/apps/report/models.py
@@ -144,6 +144,10 @@ class Report(MetaInformationArchiveAbstractModel,
             ),
         )
 
+    name = models.CharField(
+        verbose_name=_('Name'),
+        max_length=128
+    )
     generated_from = enum.EnumField(REPORT_TYPE,
                                     blank=True, null=True, editable=False)
     # TODO: Remove me after next migration run

--- a/apps/report/serializers.py
+++ b/apps/report/serializers.py
@@ -139,7 +139,10 @@ class ReportSerializer(MetaInformationSerializerMixin,
             attrs['filter_figure_end_before'] = datetime.datetime(year=year, month=12, day=31)
             attrs['name'] = f'GIDD {year}'
             attrs['is_public'] = True
+            attrs['is_pfa_visible_in_gidd'] = False
             return attrs
+        else:
+            attrs['gidd_report_year'] = None
         return attrs
 
     def validate(self, attrs) -> dict:

--- a/apps/report/serializers.py
+++ b/apps/report/serializers.py
@@ -137,7 +137,6 @@ class ReportSerializer(MetaInformationSerializerMixin,
             # Set these attrs when create or update
             attrs['filter_figure_start_after'] = datetime.datetime(year=year, month=1, day=1)
             attrs['filter_figure_end_before'] = datetime.datetime(year=year, month=12, day=31)
-            attrs['name'] = f'GIDD {year}'
             attrs['is_public'] = True
             attrs['is_pfa_visible_in_gidd'] = False
             return attrs

--- a/apps/report/tests/test_apis.py
+++ b/apps/report/tests/test_apis.py
@@ -30,6 +30,12 @@ class TestCreateReport(HelixGraphQLTestCase):
                     filterFigureCountries {
                         id
                     }
+                    filterFigureCategories
+                    filterFigureRoles
+                    filterFigureCrisisTypes
+                    isGiddReport
+                    isPublic
+                    id
                 }
                 ok
                 errors
@@ -68,6 +74,32 @@ class TestCreateReport(HelixGraphQLTestCase):
 
         content = response.json()
         self.assertIn(PERMISSION_DENIED_MESSAGE, content['errors'][0]['message'])
+
+    def test_is_gidd_report(self) -> None:
+
+        admin = create_user_with_role(USER_ROLE.ADMIN.name)
+        self.force_login(admin)
+        self.input['filterFigureCategories'] = Figure.FIGURE_CATEGORY_TYPES.NEW_DISPLACEMENT.name
+        self.input['filterFigureRoles'] = [Figure.ROLE.RECOMMENDED.name]
+        self.input['filterFigureCrisisTypes'] = [Crisis.CRISIS_TYPE.DISASTER.name]
+        self.input['isGiddReport'] = True
+        self.input['isPublic'] = False
+        self.input['giddReportYear'] = 2022
+
+        response = self.query(
+            self.mutation,
+            input_data=self.input
+        )
+
+        content = response.json()
+        data = content['data']['createReport']['result']
+
+        self.assertEqual(data['filterFigureCategories'], [])
+        self.assertEqual(data['filterFigureRoles'], [])
+        self.assertEqual(data['filterFigureCrisisTypes'], [])
+        self.assertEqual(data['filterFigureStartAfter'], '2022-01-01')
+        self.assertEqual(data['filterFigureEndBefore'], '2022-12-31')
+        self.assertEqual(data['isPublic'], True)
 
 
 class TestReportSignOff(HelixGraphQLTestCase):

--- a/apps/report/tests/test_apis.py
+++ b/apps/report/tests/test_apis.py
@@ -36,6 +36,7 @@ class TestCreateReport(HelixGraphQLTestCase):
                     isGiddReport
                     isPublic
                     id
+                    isPfaVisibleInGidd
                 }
                 ok
                 errors
@@ -100,6 +101,7 @@ class TestCreateReport(HelixGraphQLTestCase):
         self.assertEqual(data['filterFigureStartAfter'], '2022-01-01')
         self.assertEqual(data['filterFigureEndBefore'], '2022-12-31')
         self.assertEqual(data['isPublic'], True)
+        self.assertEqual(data['isPfaVisibleInGidd'], False)
 
 
 class TestReportSignOff(HelixGraphQLTestCase):

--- a/schema.graphql
+++ b/schema.graphql
@@ -517,7 +517,6 @@ type CreateEvent {
 
 input CreateExtractInputType {
   versionId: String
-  name: String!
   filterFigureCategories: [FIGURE_CATEGORY_TYPES!]
   filterFigureStartAfter: Date
   filterFigureEndBefore: Date
@@ -531,6 +530,7 @@ input CreateExtractInputType {
   filterFigureCategoryTypes: [String!]
   filterFigureHasDisaggregatedData: Boolean
   filterIsFigureToBeReviewed: Boolean
+  name: String!
   filterFigureGeographicalGroups: [ID!]
   filterFigureRegions: [ID!]
   filterFigureCountries: [ID!]
@@ -1287,7 +1287,6 @@ type ExtractionQueryObjectType {
   createdBy: UserType
   lastModifiedBy: UserType
   versionId: String
-  name: String!
   filterFigureGeographicalGroups: [GeographicalGroupType!]!
   filterFigureRegions: [CountryRegionType!]!
   filterFigureCountries: [CountryType!]!
@@ -1317,6 +1316,7 @@ type ExtractionQueryObjectType {
   filterFigureHasDisaggregatedData: Boolean
   filterContextOfViolence: [ContextOfViolenceType!]!
   filterIsFigureToBeReviewed: Boolean
+  name: String!
   entries(filterFigureEvents: [ID!], filterFigureCrises: [ID!], filterFigureGlideNumber: [String!], filterFigureSources: [ID!], filterEntryPublishers: [ID!], filterEntryArticleTitle: String, filterCreatedBy: [ID!], filterFigureRegions: [ID!], filterFigureGeographicalGroups: [ID!], filterFigureCountries: [ID!], filterFigureCategoryTypes: [String!], filterFigureCategories: [String!], filterFigureStartAfter: Date, filterFigureEndBefore: Date, filterFigureRoles: [String!], filterFigureTags: [ID!], filterFigureDisplacementTypes: [String!], filterFigureTerms: [ID!], filterFigureCrisisTypes: [String!], filterFigureDisasterCategories: [ID!], filterFigureDisasterSubCategories: [ID!], filterFigureDisasterSubTypes: [ID!], filterFigureDisasterTypes: [ID!], filterFigureViolenceSubTypes: [ID!], filterFigureViolenceTypes: [ID!], filterFigureOsvSubTypes: [ID!], filterFigureHasDisaggregatedData: Boolean, filterFigureReviewStatus: [String!], filterFigureApprovedBy: [ID!], report: String, filterContextOfViolences: [ID!], filterIsFigureToBeReviewed: Boolean, page: Int = 1, ordering: String, pageSize: Int): EntryListType
 }
 
@@ -2732,7 +2732,6 @@ type ReportType {
   disaggregationConflictCriminal: Int
   disaggregationConflictCommunal: Int
   disaggregationConflictOther: Int
-  name: String!
   filterFigureGeographicalGroups: [GeographicalGroupType!]!
   filterFigureRegions: [CountryRegionType!]!
   filterFigureCountries: [CountryType!]!
@@ -2760,6 +2759,7 @@ type ReportType {
   filterFigureHasDisaggregatedData: Boolean
   filterContextOfViolence: [ContextOfViolenceType!]!
   filterIsFigureToBeReviewed: Boolean
+  name: String!
   generatedFrom: REPORT_TYPE
   generated: Boolean!
   filterFigureStartAfter: Date
@@ -3107,7 +3107,6 @@ type UpdateEvent {
 input UpdateExtractInputType {
   id: ID!
   versionId: String
-  name: String
   filterFigureCategories: [FIGURE_CATEGORY_TYPES!]
   filterFigureStartAfter: Date
   filterFigureEndBefore: Date
@@ -3121,6 +3120,7 @@ input UpdateExtractInputType {
   filterFigureCategoryTypes: [String!]
   filterFigureHasDisaggregatedData: Boolean
   filterIsFigureToBeReviewed: Boolean
+  name: String
   filterFigureGeographicalGroups: [ID!]
   filterFigureRegions: [ID!]
   filterFigureCountries: [ID!]


### PR DESCRIPTION
## Changes

* filterFigureStartAfter should be filled (first day of year)
* filterFigureEndBefore should be filled (last day of year)
* name should be filled (GRID <year>)
* isPublic should be true
* all other fields should be null / empty

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
