### PR TITLE
Filter empty rows on disaster and displacement queries

### DIFF
--- a/apps/gidd/rest_filters.py
+++ b/apps/gidd/rest_filters.py
@@ -47,6 +47,11 @@ class RestDisasterFilterSet(ReleaseMetadataFilter):
     def filter_end_year(self, queryset, name, value):
         return queryset.filter(year__lte=value)
 
+    @property
+    def qs(self):
+        qs = super().qs
+        return qs.filter(new_displacement__gt=0)
+
 
 class RestDisplacementDataFilterSet(ReleaseMetadataFilter):
     start_year = django_filters.NumberFilter(field_name='start_year', method='filter_start_year')
@@ -68,15 +73,26 @@ class RestDisplacementDataFilterSet(ReleaseMetadataFilter):
     def filter_cause(self, queryset, name, value):
         if value == 'conflict':
             return queryset.filter(
-                Q(conflict_total_displacement__isnull=False) |
-                Q(conflict_new_displacement__isnull=False)
+                Q(conflict_new_displacement__gt=0) |
+                Q(conflict_total_displacement__gt=0)
             )
         elif value == 'disaster':
             return queryset.filter(
-                Q(disaster_total_displacement__isnull=False) |
-                Q(disaster_new_displacement__isnull=False)
+                Q(disaster_new_displacement__gt=0) |
+                Q(disaster_total_displacement__gt=0)
             )
-        return queryset
+
+    @property
+    def qs(self):
+        qs = super().qs
+        if 'cause' not in self.data:
+            return qs.filter(
+                Q(conflict_new_displacement__gt=0) |
+                Q(conflict_total_displacement__gt=0) |
+                Q(disaster_new_displacement__gt=0) |
+                Q(disaster_total_displacement__gt=0)
+            )
+        return qs
 
 
 class IdpsSaddEstimateFilter(ReleaseMetadataFilter):

--- a/apps/gidd/views.py
+++ b/apps/gidd/views.py
@@ -69,8 +69,16 @@ class DisasterViewSet(viewsets.ReadOnlyModelViewSet):
         ws = wb.active
         ws.title = "1_Disaster_Displacement_data"
         ws.append([
-            'ISO3', 'Country / Territory', 'Year', 'Event Name', 'Date of Event (start)',
-            'Disaster Internal Displacements', 'Hazard Category', 'Hazard Type', 'Hazard Sub Type'
+            'ISO3',
+            'Country / Territory',
+            'Year',
+            'Event Name',
+            'Date of Event (start)',
+            'Disaster Internal Displacements',
+            'Disaster Internal Displacements (Raw)',
+            'Hazard Category',
+            'Hazard Type',
+            'Hazard Sub Type'
         ])
         for disaster in qs:
             ws.append(
@@ -81,6 +89,7 @@ class DisasterViewSet(viewsets.ReadOnlyModelViewSet):
                     disaster.event_name,
                     disaster.start_date,
                     disaster.new_displacement_rounded,
+                    disaster.new_displacement,
                     disaster.hazard_category_name,
                     disaster.hazard_type_name,
                     disaster.hazard_sub_type_name,

--- a/schema.graphql
+++ b/schema.graphql
@@ -2475,7 +2475,7 @@ type Query {
   giddPublicCountries: [GiddPublicCountryType!]
   giddHazardTypes: [GiddHazardType]
   giddPublicFigureAnalysisList(iso3: String, year: Int, releaseEnvironment: String, page: Int = 1, ordering: String, pageSize: Int): GiddPublicFigureAnalysisListType
-  giddDisplacements(releaseEnvironment: String, startYear: Float, endYear: Float, countriesIso3: [String!], page: Int = 1, ordering: String, pageSize: Int): GiddDisplacementDataListType
+  giddDisplacements(releaseEnvironment: String, startYear: Float, endYear: Float, countriesIso3: [String!], cause: String, page: Int = 1, ordering: String, pageSize: Int): GiddDisplacementDataListType
   giddYear(releaseEnvironment: String!): GiddYearType!
   giddEvent(eventId: ID!, releaseEnvironment: String): GiddEventType
   giddCombinedStatistics(releaseEnvironment: String, hazardTypes: [ID!], countries: [String!], startYear: Float, endYear: Float, countriesIso3: [String!]): GiddCombinedStatisticsType!


### PR DESCRIPTION
- Add raw value on disaster export
- Add cause filter on displacement query

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments