### PR TITLE
Add extraction filterset in reprot figures

### DIFF
--- a/apps/report/schema.py
+++ b/apps/report/schema.py
@@ -19,6 +19,7 @@ from apps.report.enums import ReportGenerationStatusEnum
 from utils.graphene.types import CustomDjangoListObjectType
 from utils.graphene.fields import CustomPaginatedListObjectField, DjangoPaginatedListObjectField
 from utils.graphene.pagination import PageGraphqlPaginationWithoutCount
+from apps.extraction.filters import FigureExtractionFilterSet
 
 
 class ReportTotalsType(graphene.ObjectType):
@@ -116,11 +117,14 @@ class ReportType(DjangoObjectType):
         ),
         filterset_class=DummyFilter
     ))
-    figures_report = DjangoPaginatedListObjectField(FigureListType,
-                                                    accessor='report_figures',
-                                                    pagination=PageGraphqlPaginationWithoutCount(
-                                                        page_size_query_param='pageSize'
-                                                    ))
+    figures_report = DjangoPaginatedListObjectField(
+        FigureListType,
+        accessor='report_figures',
+        pagination=PageGraphqlPaginationWithoutCount(
+            page_size_query_param='pageSize'
+        ),
+        filterset_class=FigureExtractionFilterSet
+    )
     crises_report = graphene.Dynamic(lambda: CustomPaginatedListObjectField(
         get_type('apps.crisis.schema.CrisisListType'),
         accessor='crises_report',

--- a/schema.graphql
+++ b/schema.graphql
@@ -2890,7 +2890,7 @@ type ReportType {
   countriesReport(id: String, page: Int = 1, ordering: String, pageSize: Int): CountryListType
   eventsReport(id: String, page: Int = 1, ordering: String, pageSize: Int): EventListType
   entriesReport(id: String, page: Int = 1, ordering: String, pageSize: Int): EntryListType
-  figuresReport(unit: String, startDate_Lte: Date, startDate_Gte: Date, page: Int = 1, ordering: String, pageSize: Int): FigureListType
+  figuresReport(entry: ID, filterFigureRegions: [ID!], filterFigureGeographicalGroups: [ID!], filterFigureCountries: [ID!], filterFigureEvents: [ID!], filterFigureCrises: [ID!], filterFigureSources: [ID!], filterEntryPublishers: [ID!], filterFigureCategoryTypes: [String!], filterFigureCategories: [String!], filterFigureStartAfter: Date, filterFigureEndBefore: Date, filterFigureRoles: [String!], filterEntryArticleTitle: String, filterFigureTags: [ID!], filterFigureCrisisTypes: [String!], filterFigureGlideNumber: [String!], filterCreatedBy: [ID!], filterFigureDisplacementTypes: [String!], filterFigureTerms: [ID!], event: String, filterFigureDisasterCategories: [ID!], filterFigureDisasterSubCategories: [ID!], filterFigureDisasterSubTypes: [ID!], filterFigureDisasterTypes: [ID!], filterFigureViolenceSubTypes: [ID!], filterFigureViolenceTypes: [ID!], filterFigureOsvSubTypes: [ID!], filterFigureHasDisaggregatedData: Boolean, report: String, filterContextOfViolences: [ID!], filterFigureReviewStatus: [String!], filterFigureApprovedBy: [ID!], filterIsFigureToBeReviewed: Boolean, page: Int = 1, ordering: String, pageSize: Int): FigureListType
   crisesReport(id: String, page: Int = 1, ordering: String, pageSize: Int): CrisisListType
   totalDisaggregation: ReportTotalsType!
   lastGeneration: ReportGenerationType


### PR DESCRIPTION
Related to https://github.com/idmc-labs/helix2.0-meta/issues/641

## Changes

* Added extraction filterset in report figures query

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
