### PR TITLE
Fix none value redis key generation

### DIFF
--- a/apps/contrib/filters.py
+++ b/apps/contrib/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from django.db.models import Q
 
 from utils.filters import StringListFilter
 from apps.contrib.models import ExcelDownload, ClientTrackInfo, Client
@@ -91,7 +92,7 @@ class ClientTrackInfoFilter(django_filters.FilterSet):
     def qs(self):
         user = self.request.user
         if user.highest_role == USER_ROLE.ADMIN:
-            return super().qs.annotate(
+            return super().qs.filter(~Q(api_type='None')).annotate(
                 **ClientTrackInfo.annotate_api_name()
             ).select_related('client')
         return super().qs.none()

--- a/apps/contrib/models.py
+++ b/apps/contrib/models.py
@@ -343,7 +343,9 @@ class ClientTrackInfo(models.Model):
         data = ClientTrackInfoFilter(
             data=filters,
             request=DummyRequest(user=User.objects.get(id=user_id)),
-        ).qs.annotate(
+        ).qs.filter(
+            ~models.Q(api_type='None'),
+        ).annotate(
             client_name=models.F('client__name'),
             client_code=models.F('client__code'),
             api_name=models.F('api_type'),

--- a/apps/gidd/filters.py
+++ b/apps/gidd/filters.py
@@ -203,10 +203,10 @@ class DisplacementDataFilter(ReleaseMetadataFilter):
 
 # Gidd filtets to api type map
 GIDD_API_TYPE_MAP = {
-    DisasterFilter: ExternalApiDump.ExternalApiType.GIDD_DISASTER_GRAPHQL,
-    ConflictFilter: ExternalApiDump.ExternalApiType.GIDD_CONFLICT_GRAPHQL,
-    DisplacementDataFilter: ExternalApiDump.ExternalApiType.GIDD_DISPLACEMENT_DATA_GRAPHQL,
-    PublicFigureAnalysisFilter: ExternalApiDump.ExternalApiType.GIDD_PFA_GRAPHQL,
-    DisasterStatisticsFilter: ExternalApiDump.ExternalApiType.GIDD_DISASTER_STAT_GRAPHQL,
-    ConflictStatisticsFilter: ExternalApiDump.ExternalApiType.GIDD_CONFLICT_STAT_GRAPHQL,
+    f'Graphene{DisasterFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_DISASTER_GRAPHQL,
+    f'Graphene{ConflictFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_CONFLICT_GRAPHQL,
+    f'Graphene{DisplacementDataFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_DISPLACEMENT_DATA_GRAPHQL,
+    f'Graphene{PublicFigureAnalysisFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_PFA_GRAPHQL,
+    f'Graphene{DisasterStatisticsFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_DISASTER_STAT_GRAPHQL,
+    f'Graphene{ConflictStatisticsFilter.__name__}': ExternalApiDump.ExternalApiType.GIDD_CONFLICT_STAT_GRAPHQL,
 }

--- a/utils/graphene/fields.py
+++ b/utils/graphene/fields.py
@@ -1,3 +1,4 @@
+import logging
 from functools import partial
 
 from django.db.models import QuerySet
@@ -17,6 +18,10 @@ from graphene_django_extras.utils import get_extra_filters
 from utils.graphene.pagination import OrderingOnlyArgumentPagination
 from utils.common import track_gidd
 from apps.gidd.filters import GIDD_API_TYPE_MAP
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def path_has_list(info):
@@ -219,7 +224,10 @@ class DjangoPaginatedListObjectField(DjangoFilterPaginateListField):
 
         client_id = kwargs.get('client_id')
         if client_id:
-            api_type = GIDD_API_TYPE_MAP[filterset_class.__name__]
+            api_type = GIDD_API_TYPE_MAP.get(filterset_class.__name__)
+            if api_type in [None, 'None']:
+                logger.error(f'Client tracking key was found None for filter {filterset_class.__name__}')
+
             track_gidd(client_id, api_type)
 
         # setup pagination

--- a/utils/graphene/fields.py
+++ b/utils/graphene/fields.py
@@ -219,7 +219,7 @@ class DjangoPaginatedListObjectField(DjangoFilterPaginateListField):
 
         client_id = kwargs.get('client_id')
         if client_id:
-            api_type = GIDD_API_TYPE_MAP.get(filterset_class)
+            api_type = GIDD_API_TYPE_MAP[filterset_class.__name__]
             track_gidd(client_id, api_type)
 
         # setup pagination


### PR DESCRIPTION
Address
https://github.com/idmc-labs/helix-server/issues/501

## Changes
* Fix none value saved for api type in external client tracking

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [] tests
- [ ] permission checks (tests here too)
- [ ] translations
