### PR TITLE
Remove year filter from conflict endpoint

### DIFF
--- a/apps/gidd/rest_filters.py
+++ b/apps/gidd/rest_filters.py
@@ -20,7 +20,6 @@ class RestConflictFilterSet(ReleaseMetadataFilter):
         fields = {
             'id': ['iexact'],
             'iso3': ['iexact'],
-            'year': ['iexact'],
         }
 
     def filter_start_year(self, queryset, name, value):


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix-server/issues/515
## Changes

* Remove year filter from conflict public REST endpoint 

Mention related users here if any.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
