### PR TITLE
Fix issue for only listing figure category for IDPs and Internal

### DIFF
--- a/apps/extraction/filters.py
+++ b/apps/extraction/filters.py
@@ -647,7 +647,7 @@ class ReportFigureExtractionFilterSet(BaseFigureExtractionFilterSet):
         start_date = self.data.get('filter_figure_start_after')
         end_date = self.data.get('filter_figure_end_before')
 
-        flow_qs = Figure.filtered_nd_figures(
+        flow_qs = Figure.filtered_nd_figures_for_listing(
             queryset, start_date, end_date
         )
         stock_qs = Figure.filtered_idp_figures_for_listing(

--- a/apps/extraction/filters.py
+++ b/apps/extraction/filters.py
@@ -619,7 +619,7 @@ class FigureExtractionFilterSet(BaseFigureExtractionFilterSet):
         start_date = self.data.get('filter_figure_start_after')
         end_date = self.data.get('filter_figure_end_before')
 
-        flow_qs = Figure.filtered_nd_figures(
+        flow_qs = Figure.filtered_nd_figures_for_listing(
             queryset, start_date, end_date
         )
         stock_qs = Figure.filtered_idp_figures_for_listing(

--- a/apps/gidd/tasks.py
+++ b/apps/gidd/tasks.py
@@ -149,6 +149,9 @@ def update_conflict_and_disaster_data():
         role=Figure.ROLE.RECOMMENDED
     )
     for year in get_gidd_years():
+        # FIXME: Check if this should be
+        # - Figure.filtered_nd_figures_for_listing
+        # - Figure.filtered_idp_figures_for_listing
         nd_figure_qs = Figure.filtered_nd_figures(
             qs=figure_queryset,
             start_date=datetime.datetime(year=year, month=1, day=1),


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/916

## Changes
- Fix issue for listing only IDPs and Internal displacement category in extraction figure list.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
