### PR TITLE
Update copilot log-retention

### DIFF
--- a/copilot/api/manifest.yml
+++ b/copilot/api/manifest.yml
@@ -35,6 +35,8 @@ variables:
   ENABLE_DEBUG_TOOLBAR: False
   USE_S3_BUCKET: True
 
+logging:
+  retention: 90
 
 secrets:
   DJANGO_SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/DJANGO_SECRET_KEY

--- a/copilot/worker/manifest.yml
+++ b/copilot/worker/manifest.yml
@@ -31,6 +31,9 @@ variables:
   ENABLE_DEBUG_TOOLBAR: False
   USE_S3_BUCKET: True
 
+logging:
+  retention: 90
+
 secrets:
   # Same as api/manifest.yml::secrets
   DJANGO_SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/DJANGO_SECRET_KEY


### PR DESCRIPTION
Addresses
- https://github.com/idmc-labs/helix2.0-meta/issues/144#issuecomment-1757086976

Change
* Update log retention to 90 days (3 months)

NOTE: The changes are already applied to AWS through manually.
![Wed Oct 11 03:38:09 PM +0545 2023](https://github.com/idmc-labs/helix-server/assets/7059255/6fc28149-384f-4d5e-95c0-c9f245636458)


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations