### PR TITLE
Make was_Subfact field readonly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ response.json
 secrets.yml
 celerybeat-schedule
 
+*.log
+
 # testing
 /coverage
 .coverage

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -371,7 +371,6 @@ class FigureSerializer(
         fields = [
             'id',
             'entry',
-            'was_subfact',
             'quantifier',
             'reported',
             'unit',

--- a/schema.graphql
+++ b/schema.graphql
@@ -2118,7 +2118,6 @@ type FigureType {
 input FigureUpdateInputType {
   id: ID
   entry: ID
-  wasSubfact: Boolean
   quantifier: QUANTIFIER
   reported: Int
   unit: UNIT


### PR DESCRIPTION
Addresses
- https://github.com/idmc-labs/helix2.0-meta/issues/273

## Changes
- Make was_Subfact field readonly

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
