### PR TITLE
Add fallback values on diaster export

### DIFF
--- a/apps/gidd/views.py
+++ b/apps/gidd/views.py
@@ -127,11 +127,15 @@ class DisasterViewSet(ListOnlyViewSetMixin):
                     disaster.hazard_category_name,
                     disaster.hazard_type_name,
                     disaster.hazard_sub_type_name,
+                    # FIXME: Remove the fallback using glide_numbers
+                    # after GIDD is generated around 2024 May
                     EXTERNAL_ARRAY_SEPARATOR.join(
                         [f"{key}{EXTERNAL_FIELD_SEPARATOR}{value}" for key, value in zip(
                             disaster.event_codes,
                             disaster.event_codes_type
                         )]
+                    ) or EXTERNAL_ARRAY_SEPARATOR.join(
+                        [f"{key}{EXTERNAL_FIELD_SEPARATOR}Glide Number" for key in disaster.glide_numbers]
                     ),
                 ]
             )


### PR DESCRIPTION
## Related to

- https://github.com/idmc-labs/helix2.0-meta/issues/1056

## Changes

- Use glide_numbers if event_codes is empty

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
