### PR TITLE
Add read-only field constraints on mutations

### DIFF
--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -110,13 +110,6 @@ class CommonFigureValidationMixin:
             raise serializers.ValidationError('Please provide unique age range and sex.')
         return age_groups
 
-    def validate_disaggregation_strata_json(self, strata):
-        values = [each['date'] for each in strata]
-        if len(values) != len(set(values)):
-            raise serializers.ValidationError(
-                gettext('Make sure the dates are unique in a figure.'))
-        return strata
-
     def _validate_unit_and_household_size(self, instance, attrs):
         errors = OrderedDict()
 

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -371,7 +371,6 @@ class FigureSerializer(
 
     id = IntegerIDField(required=False)
     disaggregation_age = DisaggregatedAgeSerializer(many=True, required=False, allow_null=False)
-    disaggregation_strata_json = DisaggregatedStratumSerializer(many=True, required=False)
     geo_locations = OSMNameSerializer(many=True, required=False, allow_null=False)
 
     class Meta:
@@ -403,11 +402,8 @@ class FigureSerializer(
             'event',
             'context_of_violence',
             'figure_cause',
-            'violence',
             'violence_sub_type',
-            'disaster_category',
             'disaster_sub_category',
-            'disaster_type',
             'disaster_sub_type',
             'other_sub_type',
             'osv_sub_type',
@@ -425,14 +421,12 @@ class FigureSerializer(
             'disaggregation_sex_male',
             'disaggregation_sex_female',
             'disaggregation_age',
-            'disaggregation_strata_json',
             'disaggregation_conflict',
             'disaggregation_conflict_political',
             'disaggregation_conflict_criminal',
             'disaggregation_conflict_communal',
             'disaggregation_conflict_other',
             'disaggregation_age',
-            'disaggregation_strata_json',
             'geo_locations'
         ]
         extra_kwargs = {

--- a/apps/entry/serializers.py
+++ b/apps/entry/serializers.py
@@ -584,7 +584,11 @@ class EntryCreateSerializer(
 ):
     class Meta:
         model = Entry
-        exclude = ('review_status',)
+        exclude = (
+            'review_status',
+            'old_id',
+            'version_id',
+        )
 
     def validate_figures(self, figures):
         if len(figures) > Entry.FIGURES_PER_ENTRY:

--- a/apps/event/serializers.py
+++ b/apps/event/serializers.py
@@ -66,7 +66,19 @@ class EventSerializer(MetaInformationSerializerMixin,
 
     class Meta:
         model = Event
-        exclude = ('assigner', 'assigned_at', 'review_status', 'glide_numbers')
+        exclude = (
+            'assigner',
+            'assigned_at',
+            'review_status',
+            'glide_numbers',
+            'assignee',
+            'disaster_category',
+            'disaster_type',
+            'ignore_qa',
+            'old_id',
+            'version_id',
+            'violence',
+        )
 
     def validate_violence_sub_type_and_type(self, attrs):
         errors = OrderedDict()

--- a/apps/event/tests/test_apis.py
+++ b/apps/event/tests/test_apis.py
@@ -312,7 +312,6 @@ class TestUpdateEvent(HelixGraphQLTestCase):
             "eventType": "CONFLICT",
             "name": "xyz",
             "startDate": "2020-10-20",
-            "violence": v_sub_type.violence.id,
             "violenceSubType": v_sub_type.id,
             "eventCodes": [
                 {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1184,12 +1184,6 @@ type DisaggregatedAgeType {
   sexDisplay: EnumDescription
 }
 
-input DisaggregatedStratumInputType {
-  uuid: String!
-  date: Date!
-  value: Int!
-}
-
 type DisaggregatedStratumType {
   uuid: String!
   date: String
@@ -1350,8 +1344,6 @@ enum EXCEL_GENERATION_STATUS {
 }
 
 input EntryCreateInputType {
-  oldId: String
-  versionId: String
   url: String
   documentUrl: String
   articleTitle: String!
@@ -1430,8 +1422,6 @@ type EntryType {
 
 input EntryUpdateInputType {
   id: ID!
-  oldId: String
-  versionId: String
   url: String
   documentUrl: String
   articleTitle: String
@@ -1477,8 +1467,6 @@ input EventCodeUpdateInputType {
 
 input EventCreateInputType {
   eventCodes: [EventCodeInputType!]
-  oldId: String
-  versionId: String
   name: String!
   eventType: CRISIS_TYPE!
   startDate: Date!
@@ -1486,19 +1474,14 @@ input EventCreateInputType {
   endDate: Date!
   endDateAccuracy: DATE_ACCURACY
   eventNarrative: String
-  ignoreQa: Boolean
   includeTriangulationInQa: Boolean
   crisis: ID
   otherSubType: ID
-  violence: ID
   violenceSubType: ID
   actor: ID
-  disasterCategory: ID
   disasterSubCategory: ID
-  disasterType: ID
   disasterSubType: ID
   osvSubType: ID
-  assignee: ID
   countries: [ID!]
   contextOfViolence: [ID!]
 }
@@ -1608,8 +1591,6 @@ type EventType {
 input EventUpdateInputType {
   id: ID!
   eventCodes: [EventCodeUpdateInputType!]
-  oldId: String
-  versionId: String
   name: String
   eventType: CRISIS_TYPE
   startDate: Date
@@ -1617,19 +1598,14 @@ input EventUpdateInputType {
   endDate: Date
   endDateAccuracy: DATE_ACCURACY
   eventNarrative: String
-  ignoreQa: Boolean
   includeTriangulationInQa: Boolean
   crisis: ID
   otherSubType: ID
-  violence: ID
   violenceSubType: ID
   actor: ID
-  disasterCategory: ID
   disasterSubCategory: ID
-  disasterType: ID
   disasterSubType: ID
   osvSubType: ID
-  assignee: ID
   countries: [ID!]
   contextOfViolence: [ID!]
 }
@@ -2166,11 +2142,8 @@ input FigureUpdateInputType {
   event: ID
   contextOfViolence: [ID!]
   figureCause: CRISIS_TYPE
-  violence: ID
   violenceSubType: ID
-  disasterCategory: ID
   disasterSubCategory: ID
-  disasterType: ID
   disasterSubType: ID
   otherSubType: ID
   osvSubType: ID
@@ -2186,7 +2159,6 @@ input FigureUpdateInputType {
   disaggregationSexMale: Int
   disaggregationSexFemale: Int
   disaggregationAge: [DisaggregatedAgeInputType!]
-  disaggregationStrataJson: [DisaggregatedStratumInputType!]
   disaggregationConflict: Int
   disaggregationConflictPolitical: Int
   disaggregationConflictCriminal: Int


### PR DESCRIPTION
Addresses
- https://github.com/orgs/idmc-labs/projects/2?pane=issue&itemId=51744530
- https://github.com/orgs/idmc-labs/projects/2?pane=issue&itemId=51744721
- https://github.com/orgs/idmc-labs/projects/2/?pane=issue&itemId=51844997
- https://github.com/orgs/idmc-labs/projects/2/?pane=issue&itemId=51981438

## Changes

- Add read-only field constraints for 'oldId', 'versionId' in mutations: CreateEntry and UpdateEntry
- Add read-only field constraints for 'assignee', 'disasterCategory', 'disasterType', 'ignoreQa', 'oldId', 'versionId', 'violence' in mutations: CreateEvent and UpdateEvent
- Add read-only field constraints for 'violence', 'disasterCategory', 'disasterType', 'disaggregationStrataJson' in mutations: bulkUpdateFigures

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
