### PR TITLE
Add management command for populating calculation_logic on Figure model

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ sh deploy/scripts/s3_bucket_setup.sh
 ```bash
 python manage.py addstatictoken -t 123456 "admin@idmcdb.org"
 ```
+
+## Management Command
+There are custom management commands available to facilitate specific tasks.
+
+### Populate figure `Calculation Logic`
+```bash
+./manage.py populate_calculation_logic_field
+```
+> NOTE: This command populates the `calculation_logic` field in the Figure Table if there is no existing data in it.
+

--- a/apps/entry/management/commands/populate_calculation_logic_field.py
+++ b/apps/entry/management/commands/populate_calculation_logic_field.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from apps.entry.models import Figure
+
+
+class Command(BaseCommand):
+    help = 'Populate a calculation_logic field on the Figure table if it was blank for existing data'
+
+    def handle(self, *args, **options):
+        figures_without_calculation_logic_data = Figure.objects.filter(
+            Q(calculation_logic__isnull=True) | Q(calculation_logic='')
+        )
+
+        resp = figures_without_calculation_logic_data.update(calculation_logic='Not available')
+
+        self.stdout.write(
+            self.style.SUCCESS(f'Successfully populated the blank calculation_logic field on the Figure table. {resp}')
+        )


### PR DESCRIPTION
Addresses
 - https://github.com/idmc-labs/helix2.0-meta/issues/1043

## Changes
- Add management command for populating calculation_logic field on Figure table

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations

## Deployment

- We need to run the command on the server manually `./manage.py populate_calculation_logic_field`