### PR TITLE
Update the label for displacement_ocurred

### DIFF
--- a/apps/entry/views.py
+++ b/apps/entry/views.py
@@ -136,8 +136,8 @@ def get_idu_data(filters=None):
             ),
         ),
         displacement_occurred_transformed=Case(
-            When(displacement_occurred=0, then=Value("Displacement due to preventive evacuation")),
-            When(displacement_occurred__in=[1, 2, 3], then=Value("Displacement without preventive evacuation")),
+            When(displacement_occurred=0, then=Value("Displacement due to preventive evacuation reported")),
+            When(displacement_occurred__in=[1, 2, 3], then=Value("Displacement without preventive evacuation reported")),
             output_field=CharField()
         ),
         custom_figure_text=Case(

--- a/apps/gidd/views.py
+++ b/apps/gidd/views.py
@@ -207,6 +207,7 @@ class DisasterViewSet(ListOnlyViewSetMixin):
         response = HttpResponse(content=save_virtual_workbook(wb))
         filename = 'IDMC_GIDD_Disasters_Internal_Displacement_Data.xlsx'
         response['Content-Disposition'] = f'attachment; filename={filename}'
+        response['Content-Type'] = 'application/octet-stream'
         return response
 
 
@@ -577,6 +578,7 @@ class DisplacementDataViewSet(ListOnlyViewSetMixin):
         response = HttpResponse(content=save_virtual_workbook(wb))
         filename = 'IDMC_Internal_Displacement_Conflict-Violence_Disasters.xlsx'
         response['Content-Disposition'] = f'attachment; filename={filename}'
+        response['Content-Type'] = 'application/octet-stream'
         return response
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,11 @@ services:
       context: ./
       dockerfile: worker.Dockerfile
     command: python manage.py run_celery_dev
+    # Fix 100% CPU usage on archlinux (https://github.com/goauthentik/authentik/pull/7762)
+    ulimits:
+      nofile:
+        soft: 10240
+        hard: 10240
 
 volumes:
   helix-db-13-data:

--- a/helix/settings.py
+++ b/helix/settings.py
@@ -641,6 +641,7 @@ SPECTACULAR_SETTINGS = {
     'CONTACT': {'email': 'info@idmc.ch'},
     "SWAGGER_UI_SETTINGS": {
         "deepLinking": True,
+        "syntaxHighlight": False,  # Disabling syntax highlighting as it takes considerable time to load
         "persistAuthorization": True,
         "displayOperationId": True,
     },


### PR DESCRIPTION
## Addresses

- https://github.com/idmc-labs/helix2.0-meta/issues/1090 (partially) 
- https://github.com/idmc-labs/helix2.0-meta/issues/882 (partially)

## Changes

- Update the label for displacement_ocurred
- Add content type as octet-stream on xlsx export
  - File downloaded from Swagger UI would be corrupted before
- Disable syntax highlighting in swagger ui
  - User should be able to load idus api (except idus-all)
  - There is an on-going issue about large payload json at https://github.com/swagger-api/swagger-ui/issues/3832
- Fix 100% CPU usage celery issue on systems like arch linux

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
