### PR TITLE
Event-Figures: End date error

### DIFF
--- a/utils/validations.py
+++ b/utils/validations.py
@@ -10,8 +10,10 @@ class MissingCaptchaException(Exception):
 
 
 def is_child_parent_dates_valid(
-    c_start_date, c_end_date,
-    p_start_date, p_name
+    c_start_date,
+    c_end_date,
+    p_start_date,
+    p_name
 ) -> OrderedDict:
     """
     c = child
@@ -25,7 +27,7 @@ def is_child_parent_dates_valid(
         return errors
     if c_start_date and p_start_date and p_start_date > c_start_date:
         errors['start_date'] = gettext('Choose your start date after %s start date: %s.') % (
-            p_name,
+            p_name or 'parent',
             p_start_date
         )
     return errors


### PR DESCRIPTION
## Changes
- Implement validation to ensure end dates are not before start dates.

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
