### PR TITLE
Undo filters for displacement, PublicFigureAnalysis, and disaster exports

### DIFF
--- a/apps/gidd/rest_filters.py
+++ b/apps/gidd/rest_filters.py
@@ -28,19 +28,43 @@ class RestConflictFilterSet(ReleaseMetadataFilter):
         }
 
     def filter_start_year(self, queryset, name, value):
+        if not value:
+            return queryset
         return queryset.filter(year__gte=value)
 
     def filter_end_year(self, queryset, name, value):
+        if not value:
+            return queryset
         return queryset.filter(year__lte=value)
 
 
 class RestDisasterFilterSet(ReleaseMetadataFilter):
+    event_name = django_filters.CharFilter(method='filter_event_name')
+    start_year = django_filters.NumberFilter(field_name='start_year', method='filter_start_year')
+    end_year = django_filters.NumberFilter(field_name='end_year', method='filter_end_year')
 
     class Meta:
         model = Disaster
         fields = {
-            'iso3': ['iexact'],
+            'event_name': ['icontains'],
+            'iso3': ['in'],
+            'hazard_type': ['in'],
         }
+
+    def filter_event_name(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(event_name__icontains=value)
+
+    def filter_start_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__gte=value)
+
+    def filter_end_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__lte=value)
 
     @property
     def qs(self):
@@ -53,12 +77,24 @@ class RestDisplacementDataFilterSet(ReleaseMetadataFilter):
         method='filter_cause',
         choices=get_name_choices(Crisis.CRISIS_TYPE),
     )
+    start_year = django_filters.NumberFilter(field_name='start_year', method='filter_start_year')
+    end_year = django_filters.NumberFilter(field_name='end_year', method='filter_end_year')
 
     class Meta:
         model = DisplacementData
         fields = {
-            'iso3': ['iexact'],
+            'iso3': ['in'],
         }
+
+    def filter_start_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__gte=value)
+
+    def filter_end_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__lte=value)
 
     def filter_cause(self, queryset, name, value):
         if value.lower() == Crisis.CRISIS_TYPE.CONFLICT.name.lower():
@@ -71,6 +107,8 @@ class RestDisplacementDataFilterSet(ReleaseMetadataFilter):
                 Q(disaster_new_displacement__gt=0) |
                 Q(disaster_total_displacement__gt=0)
             )
+        if not value:
+            return queryset
 
     @property
     def qs(self):
@@ -90,12 +128,24 @@ class IdpsSaddEstimateFilter(ReleaseMetadataFilter):
         method='filter_cause',
         choices=get_name_choices(Crisis.CRISIS_TYPE),
     )
+    start_year = django_filters.NumberFilter(field_name='start_year', method='filter_start_year')
+    end_year = django_filters.NumberFilter(field_name='end_year', method='filter_end_year')
 
     class Meta:
         model = IdpsSaddEstimate
         fields = {
-            'iso3': ['iexact'],
+            'iso3': ['in'],
         }
+
+    def filter_start_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__gte=value)
+
+    def filter_end_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__lte=value)
 
     def filter_cause(self, queryset, name, value):
         # NOTE: this filter is used inside displacement export
@@ -107,6 +157,8 @@ class IdpsSaddEstimateFilter(ReleaseMetadataFilter):
             return queryset.filter(
                 cause=Crisis.CRISIS_TYPE.DISASTER.value,
             )
+        if not value:
+            return queryset
         return queryset
 
 
@@ -115,12 +167,24 @@ class PublicFigureAnalysisFilterSet(ReleaseMetadataFilter):
         method='filter_cause',
         choices=get_name_choices(Crisis.CRISIS_TYPE),
     )
+    start_year = django_filters.NumberFilter(field_name='start_year', method='filter_start_year')
+    end_year = django_filters.NumberFilter(field_name='end_year', method='filter_end_year')
 
     class Meta:
         model = PublicFigureAnalysis
         fields = {
-            'iso3': ['iexact'],
+            'iso3': ['in'],
         }
+
+    def filter_start_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__gte=value)
+
+    def filter_end_year(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(year__lte=value)
 
     def filter_cause(self, queryset, name, value):
         # NOTE: this filter is used inside displacement export
@@ -163,6 +227,8 @@ class DisaggregationFilterSet(django_filters.FilterSet):
             return queryset.filter(
                 cause=Crisis.CRISIS_TYPE.DISASTER.value,
             )
+        if not value:
+            return queryset
         return queryset
 
     def no_op(self, qs, name, value):

--- a/apps/gidd/views.py
+++ b/apps/gidd/views.py
@@ -219,7 +219,7 @@ class DisasterViewSet(ListOnlyViewSetMixin):
         ws2.append([])
 
         table = [
-            ['ISO3: ISO 3166-1 alpha-3. The ISO3 "AB9" was assigned to the Abyei Area.'],
+            ['ISO3: ISO 3166-1 alpha-3 \'AB9\' was assigned to the Abyei Area.'],
             ['Country / Territory: Short name of the country or territory.'],
             ['Year: The year for which displacement figures are reported.'],
             [
@@ -487,7 +487,7 @@ class DisplacementDataViewSet(ListOnlyViewSetMixin):
                 'Centre (IDMC).'
             ],
             [''],
-            ['ISO3: ISO 3166-1 alpha-3 “AB9” was assigned to the Abyei Area.'],
+            ['ISO3: ISO 3166-1 alpha-3 \'AB9\' was assigned to the Abyei Area.'],
             ['Country / Territory: Short name of the country or territory.'],
             ['Year: The year for which displacement figures are reported.'],
             [
@@ -541,8 +541,9 @@ class DisplacementDataViewSet(ListOnlyViewSetMixin):
                 'metric, reporting year, and country.'
             ],
             [],
-            ['ISO3: ISO 3166-1 alpha-3  "AB9" was assigned to the Abyei Area.'],
+            ['ISO3: ISO 3166-1 alpha-3 \'AB9\' was assigned to the Abyei Area.'],
             ['Year: The year for which displacement figures are reported.'],
+            ['figure_cause_name: Trigger of displacement'],
             [
                 'figure_category_name: Type of displacement metric, this field contrains values of '
                 'Internal displacements (population flows) and  IDPs  (Total number of IDPs  or population stocks)'
@@ -558,7 +559,7 @@ class DisplacementDataViewSet(ListOnlyViewSetMixin):
         for item in readme_text_3:
             ws4.append(item)
         readme_text_4 = [
-            ['ISO3: ISO 3166-1 alpha-3. The ISO3 “AB9” was assigned to the Abyei Area.'],
+            ['ISO3: ISO 3166-1 alpha-3 \'AB9\' was assigned to the Abyei Area.'],
             ['Country: Short name of the country or territory.'],
             ['Geographical region: Geographical region'],
             ['Year: The year for which displacement figures are reported.'],


### PR DESCRIPTION
Addresses
- https://github.com/idmc-labs/helix2.0-meta/issues/1158

## Changes

* Undo filters for displacement and disaster exports
* Undo filters for PublicFigureAnalysis export
* Update README tab on GIDD exports

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
