### PR TITLE
Use write_only mode in excel generation

### DIFF
--- a/apps/gidd/views.py
+++ b/apps/gidd/views.py
@@ -119,9 +119,8 @@ class DisasterViewSet(ListOnlyViewSetMixin):
         Export disaster
         """
         qs = self.filter_queryset(self.get_queryset())
-        wb = Workbook()
-        ws = wb.active
-        ws.title = "1_Disaster_Displacement_data"
+        wb = Workbook(write_only=True)
+        ws = wb.create_sheet('1_Disaster_Displacement_data')
         ws.append([
             'ISO3',
             'Country / Territory',
@@ -401,10 +400,9 @@ class DisplacementDataViewSet(ListOnlyViewSetMixin):
             'iso3',
         )
 
-        wb = Workbook()
-        ws = wb.active
+        wb = Workbook(write_only=True)
         # Tab 1
-        ws.title = "1_Displacement_data"
+        ws = wb.create_sheet('1_Displacement_data')
         if request.GET.get('cause') == 'conflict':
             self.export_conflicts(ws, qs)
         elif request.GET.get('cause') == 'disaster':
@@ -1016,9 +1014,9 @@ class DisaggregationViewSet(ListOnlyViewSetMixin):
         return response
 
     def _export_disaggregated_excel(self, qs):
-        wb = Workbook()
-        ws = wb.active
-        ws.title = "1_Disaggregated_Data"
+        wb = Workbook(write_only=True)
+
+        ws = wb.create_sheet('1_Disaggregated_Data')
         ws.append([
             'ID',
             'ISO3',

--- a/copilot/api/manifest.yml
+++ b/copilot/api/manifest.yml
@@ -55,7 +55,7 @@ environments:
   staging:
     http:
       alias: helix-tools-api-staging.idmcdb.org
-    cpu: 256
+    cpu: 1024
     memory: 2048
     count:
       range: 1-2

--- a/copilot/worker/manifest.yml
+++ b/copilot/worker/manifest.yml
@@ -49,7 +49,7 @@ secrets:
 # You can override any of the values defined above by environment.
 environments:
   staging:
-    cpu: 256
+    cpu: 1024
     memory: 2048
     count:
       range: 1-2


### PR DESCRIPTION
## Changes

* Use write_only mode when creating excel files

Mention related users here if any.

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
