### PR TITLE
Fix AttributeError in StatusLog last_release_date method

### DIFF
--- a/apps/gidd/models.py
+++ b/apps/gidd/models.py
@@ -159,7 +159,7 @@ class StatusLog(models.Model):
 
     @classmethod
     def last_release_date(cls):
-        last_log = StatusLog.objects.last()
+        last_log = StatusLog.objects.filter(completed_at__isnull=False).last()
         return last_log.completed_at.strftime("%B %d, %Y") if last_log else None
 
 


### PR DESCRIPTION
Addresses 

## Changes
Fix AttributeError in StatusLog last_release_date method

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
