### PR TITLE
Append missing AHHS values from the new dataset provided by IDMC

### DIFF
--- a/apps/entry/management/commands/fix_ahhs_data.py
+++ b/apps/entry/management/commands/fix_ahhs_data.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import logging
 from decimal import Decimal
 
 from django.core.management.base import BaseCommand
@@ -9,6 +8,7 @@ from helix.managers import BulkUpdateManager
 
 from apps.entry.models import Figure
 from utils.common import round_half_up
+
 
 class Command(BaseCommand):
 

--- a/apps/entry/management/commands/fix_ahhs_data.py
+++ b/apps/entry/management/commands/fix_ahhs_data.py
@@ -81,10 +81,6 @@ class Command(BaseCommand):
         if not os.path.exists(csv_file_path):
             self.stdout.write(self.style.ERROR(f"CSV file path does not exist: {csv_file_path}"))
             return
-        try:
-            self.patch_figure_household_from_csv(csv_file_path)
-            self.stdout.write("AHHS data patched successfully.")
-        except FileNotFoundError:
-            self.stdout.write(self.style.ERROR(f"CSV file at {csv_file_path} not found."))
-        except Exception:
-            self.stdout.write(self.style.ERROR("Failed to patch AHHS data:", exc_info=True))
+
+        self.patch_figure_household_from_csv(csv_file_path)
+        self.stdout.write("AHHS data patched successfully.")


### PR DESCRIPTION
Addresses
- https://github.com/idmc-labs/helix2.0-meta/issues/1172

## Changes
Append new AHHS data and recalculate total figures

- Append missing AHHS values from the new dataset provided by IDMC
- Add migration script to integrate new AHHS data without overwriting past values
- Recalculate total figures and update household size for the year 2024 for specified countries (Croatia, Lebanon, Libya)
- Preserve figures for other years and those manually updated
- Implement checks to avoid duplicate data for a country and year

## CSV File:
OBSOLETE: [append_ahhs_data.csv](https://github.com/user-attachments/files/15550998/append_ahhs_data.csv)
NEW: [update_ahhs_two.csv](https://github.com/user-attachments/files/15585473/update_ahhs_two.csv)


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
