### PR TITLE
fix(ci): prevent test_runner workflow from running on fork PRs

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   build:
 
+    # Run this workflow only for PRs or push events from the same repo (exclude forks)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test_runner_forks.yml
+++ b/.github/workflows/test_runner_forks.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   build:
 
+    # Ensure this workflow only runs for PRs or push events from forks
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This commit modifies the test_runner.yml GitHub Actions workflow to ensure it doesn't run for pull requests from forks. The change adds a condition to the build job that allows the workflow to run only for push events or pull requests from the same repository.

This change improves CI efficiency and security by preventing unnecessary workflow runs on fork PRs.

## Changes

- Add condition to default test runner to exclude forks
- Ensures test_runner_forks.yml handles PRs from forks exclusively
- Maintains original functionality for push events and internal PRs

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
